### PR TITLE
feat: Add streaming support for Docker command output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ tokio = { version = "1.46", features = [
     "rt-multi-thread",
     "macros",
     "time",
+    "io-util",
+    "sync",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -1,0 +1,238 @@
+//! Example demonstrating streaming output from Docker commands
+//!
+//! This example shows how to use the streaming API to get real-time output
+//! from Docker commands like build, run, and logs.
+//!
+//! Run with: cargo run --example streaming
+
+use docker_wrapper::command::DockerCommand;
+use docker_wrapper::{BuildCommand, LogsCommand, RunCommand};
+use docker_wrapper::{OutputLine, StreamHandler, StreamableCommand};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Docker Streaming Example");
+    println!("========================\n");
+
+    // Example 1: Stream build output
+    example_build_streaming().await?;
+
+    // Example 2: Stream container output
+    example_run_streaming().await?;
+
+    // Example 3: Stream logs with filtering
+    example_logs_filtering().await?;
+
+    // Example 4: Channel-based streaming
+    example_channel_streaming().await?;
+
+    println!("\n✨ All streaming examples completed!");
+    Ok(())
+}
+
+async fn example_build_streaming() -> Result<(), Box<dyn std::error::Error>> {
+    println!("📦 Example 1: Streaming Docker Build Output");
+    println!("-------------------------------------------");
+
+    // Create a simple Dockerfile for testing
+    std::fs::write(
+        "Dockerfile.streaming",
+        r#"
+FROM alpine:latest
+RUN echo "Step 1: Installing packages..."
+RUN echo "Step 2: Setting up application..."
+RUN echo "Step 3: Configuring environment..."
+CMD ["echo", "Build complete!"]
+"#,
+    )?;
+
+    println!("Building image with streaming output...\n");
+
+    // Stream build output to console
+    let result = BuildCommand::new(".")
+        .file("Dockerfile.streaming")
+        .tag("streaming-example:latest")
+        .stream(StreamHandler::print())
+        .await?;
+
+    if result.is_success() {
+        println!("\n✅ Build completed successfully!");
+    } else {
+        println!("\n❌ Build failed with exit code: {}", result.exit_code);
+    }
+
+    // Clean up
+    std::fs::remove_file("Dockerfile.streaming")?;
+
+    Ok(())
+}
+
+async fn example_run_streaming() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n🚀 Example 2: Streaming Container Output");
+    println!("----------------------------------------");
+
+    // Run a container that produces output over time
+    println!("Running container with streaming output...\n");
+
+    let line_count = Arc::new(AtomicUsize::new(0));
+    let count_clone = line_count.clone();
+
+    let result = RunCommand::new("alpine")
+        .cmd(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "for i in 1 2 3 4 5; do echo \"Line $i\"; sleep 0.1; done".to_string(),
+        ])
+        .remove() // Remove container after exit
+        .stream(move |line| match line {
+            OutputLine::Stdout(text) => {
+                println!("Container: {}", text);
+                count_clone.fetch_add(1, Ordering::SeqCst);
+            }
+            OutputLine::Stderr(text) => {
+                eprintln!("Container Error: {}", text);
+            }
+        })
+        .await?;
+
+    println!("\n✅ Container exited with code: {}", result.exit_code);
+    println!(
+        "   Processed {} lines of output",
+        line_count.load(Ordering::SeqCst)
+    );
+
+    Ok(())
+}
+
+async fn example_logs_filtering() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n📜 Example 3: Streaming Logs with Filtering");
+    println!("-------------------------------------------");
+
+    // First, create a container that generates logs
+    println!("Creating a container for log streaming...");
+
+    let container_name = "streaming-log-example";
+
+    // Run a container in detached mode that generates logs
+    RunCommand::new("alpine")
+        .name(container_name)
+        .detach()
+        .remove()
+        .cmd(vec!["sh".to_string(), "-c".to_string(), "for i in 1 2 3 4 5; do echo \"Log entry $i\"; echo \"Error: Something went wrong $i\" >&2; sleep 1; done".to_string()])
+        .execute()
+        .await?;
+
+    println!("Streaming logs with custom filtering...\n");
+
+    // Stream logs with a custom filter
+    let mut error_count = 0;
+    let mut info_count = 0;
+
+    let _result = LogsCommand::new(container_name)
+        .follow()
+        .timestamps()
+        .tail("all")
+        .stream(move |line| match line {
+            OutputLine::Stdout(text) => {
+                if text.contains("Log entry") {
+                    println!("[INFO] {}", text);
+                    info_count += 1;
+                }
+            }
+            OutputLine::Stderr(text) => {
+                if text.contains("Error") {
+                    eprintln!("[ERROR] {}", text);
+                    error_count += 1;
+                }
+            }
+        })
+        .await;
+
+    // Note: The logs command will continue until the container exits
+    println!("\n✅ Log streaming completed");
+    println!("   Info messages: {}", info_count);
+    println!("   Error messages: {}", error_count);
+
+    // Stop and remove the container
+    let _ = std::process::Command::new("docker")
+        .args(&["stop", container_name])
+        .output();
+
+    Ok(())
+}
+
+async fn example_channel_streaming() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n📡 Example 4: Channel-based Streaming");
+    println!("-------------------------------------");
+
+    println!("Using channel to process output asynchronously...\n");
+
+    // Run a command that produces output
+    let (mut rx, _result) = RunCommand::new("alpine")
+        .cmd(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "for i in 1 2 3; do echo \"Data: $i\"; sleep 0.5; done".to_string(),
+        ])
+        .remove()
+        .stream_channel()
+        .await?;
+
+    // Process output from channel in a separate task
+    let processor = tokio::spawn(async move {
+        let mut lines = Vec::new();
+        while let Some(line) = rx.recv().await {
+            match line {
+                OutputLine::Stdout(text) => {
+                    println!("Received via channel: {}", text);
+                    lines.push(text);
+                }
+                OutputLine::Stderr(text) => {
+                    eprintln!("Error via channel: {}", text);
+                }
+            }
+        }
+        lines
+    });
+
+    // Wait for both the command and processor to complete
+    let lines = processor.await?;
+
+    println!("\n✅ Channel streaming completed");
+    println!("   Collected {} lines via channel", lines.len());
+
+    Ok(())
+}
+
+// Additional example: Progress tracking during build
+#[allow(dead_code)]
+async fn example_build_progress() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n🏗️  Bonus: Build Progress Tracking");
+    println!("---------------------------------");
+
+    let mut current_step = 0;
+    let total_steps = 5;
+
+    let result = BuildCommand::new(".")
+        .tag("progress-example:latest")
+        .stream(move |line| {
+            if let OutputLine::Stdout(text) = line {
+                if text.contains("Step") {
+                    current_step += 1;
+                    let progress = (current_step as f32 / total_steps as f32) * 100.0;
+                    println!("[{:.0}%] {}", progress, text);
+                } else {
+                    println!("       {}", text);
+                }
+            }
+        })
+        .await?;
+
+    if result.is_success() {
+        println!("\n✅ Build completed with progress tracking!");
+    }
+
+    Ok(())
+}

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -1797,7 +1797,7 @@ impl RunCommand {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let result = RunCommand::new("alpine")
-    ///     .cmd(vec!["echo", "Hello, World!"])
+    ///     .cmd(vec!["echo".to_string(), "Hello, World!".to_string()])
     ///     .stream(StreamHandler::print())
     ///     .await?;
     /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub mod command;
 pub mod compose;
 pub mod error;
 pub mod prerequisites;
+pub mod stream;
+
+pub use stream::{OutputLine, StreamHandler, StreamResult, StreamableCommand};
 
 pub use command::{
     attach::{AttachCommand, AttachResult},

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,307 @@
+//! Streaming support for Docker command output.
+//!
+//! This module provides functionality to stream output from long-running Docker
+//! commands in real-time, rather than waiting for completion.
+
+use crate::error::Result;
+use async_trait::async_trait;
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command as TokioCommand;
+use tokio::sync::mpsc;
+
+/// Represents a line of output from a streaming command
+#[derive(Debug, Clone)]
+pub enum OutputLine {
+    /// Standard output line
+    Stdout(String),
+    /// Standard error line  
+    Stderr(String),
+}
+
+/// Result returned from streaming commands
+#[derive(Debug, Clone)]
+pub struct StreamResult {
+    /// Exit code of the command
+    pub exit_code: i32,
+    /// Whether the command succeeded (exit code 0)
+    pub success: bool,
+    /// Accumulated stdout if captured
+    pub stdout: Option<String>,
+    /// Accumulated stderr if captured
+    pub stderr: Option<String>,
+}
+
+impl StreamResult {
+    /// Check if the command was successful
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        self.success
+    }
+}
+
+/// Trait for commands that support streaming output
+#[async_trait]
+pub trait StreamableCommand: Send + Sync {
+    /// Run the command with streaming output
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command fails to spawn or encounters an I/O error
+    async fn stream<F>(&self, handler: F) -> Result<StreamResult>
+    where
+        F: FnMut(OutputLine) + Send + 'static;
+
+    /// Run the command with streaming output via a channel
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the command fails to spawn or encounters an I/O error
+    async fn stream_channel(&self) -> Result<(mpsc::Receiver<OutputLine>, StreamResult)>;
+}
+
+/// Stream handler utilities
+pub struct StreamHandler;
+
+impl StreamHandler {
+    /// Print output lines to stdout/stderr
+    pub fn print() -> impl FnMut(OutputLine) {
+        move |line| match line {
+            OutputLine::Stdout(s) => println!("{s}"),
+            OutputLine::Stderr(s) => eprintln!("{s}"),
+        }
+    }
+
+    /// Collect output while also calling another handler
+    pub fn tee<F>(mut handler: F) -> impl FnMut(OutputLine) -> (Vec<String>, Vec<String>)
+    where
+        F: FnMut(&OutputLine),
+    {
+        let mut stdout_lines = Vec::new();
+        let mut stderr_lines = Vec::new();
+
+        move |line| {
+            handler(&line);
+            match line {
+                OutputLine::Stdout(s) => stdout_lines.push(s),
+                OutputLine::Stderr(s) => stderr_lines.push(s),
+            }
+            (stdout_lines.clone(), stderr_lines.clone())
+        }
+    }
+
+    /// Filter lines by pattern
+    pub fn filter(pattern: String) -> impl FnMut(OutputLine) -> Option<String> {
+        move |line| {
+            let text = match &line {
+                OutputLine::Stdout(s) | OutputLine::Stderr(s) => s,
+            };
+            if text.contains(&pattern) {
+                Some(text.clone())
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Log output lines with a prefix
+    pub fn with_prefix(prefix: String) -> impl FnMut(OutputLine) {
+        move |line| match line {
+            OutputLine::Stdout(s) => println!("{prefix}: {s}"),
+            OutputLine::Stderr(s) => eprintln!("{prefix} (error): {s}"),
+        }
+    }
+}
+
+/// Internal helper to spawn a streaming command
+pub(crate) async fn stream_command(
+    mut cmd: TokioCommand,
+    mut handler: impl FnMut(OutputLine) + Send + 'static,
+) -> Result<StreamResult> {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| crate::error::Error::custom(format!("Failed to spawn command: {e}")))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| crate::error::Error::custom("Failed to capture stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| crate::error::Error::custom("Failed to capture stderr"))?;
+
+    let stdout_reader = BufReader::new(stdout);
+    let stderr_reader = BufReader::new(stderr);
+    let mut stdout_lines = stdout_reader.lines();
+    let mut stderr_lines = stderr_reader.lines();
+
+    let mut stdout_accumulator = Vec::new();
+    let mut stderr_accumulator = Vec::new();
+
+    loop {
+        tokio::select! {
+            line = stdout_lines.next_line() => {
+                match line {
+                    Ok(Some(text)) => {
+                        stdout_accumulator.push(text.clone());
+                        handler(OutputLine::Stdout(text));
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        return Err(crate::error::Error::custom(
+                            format!("Error reading stdout: {e}")
+                        ));
+                    }
+                }
+            }
+            line = stderr_lines.next_line() => {
+                match line {
+                    Ok(Some(text)) => {
+                        stderr_accumulator.push(text.clone());
+                        handler(OutputLine::Stderr(text));
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        return Err(crate::error::Error::custom(
+                            format!("Error reading stderr: {e}")
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| crate::error::Error::custom(format!("Failed to wait for command: {e}")))?;
+
+    Ok(StreamResult {
+        exit_code: status.code().unwrap_or(-1),
+        success: status.success(),
+        stdout: Some(stdout_accumulator.join("\n")),
+        stderr: Some(stderr_accumulator.join("\n")),
+    })
+}
+
+/// Internal helper to spawn a streaming command with channel output
+pub(crate) async fn stream_command_channel(
+    mut cmd: TokioCommand,
+) -> Result<(mpsc::Receiver<OutputLine>, StreamResult)> {
+    let (tx, rx) = mpsc::channel(100);
+
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| crate::error::Error::custom(format!("Failed to spawn command: {e}")))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| crate::error::Error::custom("Failed to capture stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| crate::error::Error::custom("Failed to capture stderr"))?;
+
+    let tx_clone = tx.clone();
+
+    // Spawn task to read stdout
+    let stdout_task = tokio::spawn(async move {
+        let reader = BufReader::new(stdout);
+        let mut reader_lines = reader.lines();
+        let mut lines = Vec::new();
+        while let Ok(Some(line)) = reader_lines.next_line().await {
+            lines.push(line.clone());
+            let _ = tx.send(OutputLine::Stdout(line)).await;
+        }
+        lines
+    });
+
+    // Spawn task to read stderr
+    let stderr_task = tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut reader_lines = reader.lines();
+        let mut lines = Vec::new();
+        while let Ok(Some(line)) = reader_lines.next_line().await {
+            lines.push(line.clone());
+            let _ = tx_clone.send(OutputLine::Stderr(line)).await;
+        }
+        lines
+    });
+
+    // Wait for both tasks and the process
+    let status_future = child.wait();
+    let (stdout_lines, stderr_lines, status) =
+        tokio::join!(stdout_task, stderr_task, status_future);
+
+    let stdout_lines = stdout_lines.unwrap_or_default();
+    let stderr_lines = stderr_lines.unwrap_or_default();
+    let status = status
+        .map_err(|e| crate::error::Error::custom(format!("Failed to wait for command: {e}")))?;
+
+    Ok((
+        rx,
+        StreamResult {
+            exit_code: status.code().unwrap_or(-1),
+            success: status.success(),
+            stdout: Some(stdout_lines.join("\n")),
+            stderr: Some(stderr_lines.join("\n")),
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_output_line() {
+        let stdout = OutputLine::Stdout("test".to_string());
+        let stderr = OutputLine::Stderr("error".to_string());
+
+        match stdout {
+            OutputLine::Stdout(s) => assert_eq!(s, "test"),
+            _ => panic!("Wrong variant"),
+        }
+
+        match stderr {
+            OutputLine::Stderr(s) => assert_eq!(s, "error"),
+            _ => panic!("Wrong variant"),
+        }
+    }
+
+    #[test]
+    fn test_stream_result() {
+        let result = StreamResult {
+            exit_code: 0,
+            success: true,
+            stdout: Some("output".to_string()),
+            stderr: None,
+        };
+
+        assert!(result.is_success());
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, Some("output".to_string()));
+        assert!(result.stderr.is_none());
+    }
+
+    #[test]
+    fn test_stream_handler_filter() {
+        let mut filter = StreamHandler::filter("error".to_string());
+
+        let result1 = filter(OutputLine::Stdout(
+            "this contains error message".to_string(),
+        ));
+        assert_eq!(result1, Some("this contains error message".to_string()));
+
+        let result2 = filter(OutputLine::Stdout("normal message".to_string()));
+        assert!(result2.is_none());
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -268,12 +268,12 @@ mod tests {
 
         match stdout {
             OutputLine::Stdout(s) => assert_eq!(s, "test"),
-            _ => panic!("Wrong variant"),
+            OutputLine::Stderr(_) => panic!("Wrong variant"),
         }
 
         match stderr {
             OutputLine::Stderr(s) => assert_eq!(s, "error"),
-            _ => panic!("Wrong variant"),
+            OutputLine::Stdout(_) => panic!("Wrong variant"),
         }
     }
 


### PR DESCRIPTION
## Summary
Implements streaming support for Docker commands, allowing real-time output processing instead of waiting for command completion. This is essential for long-running operations like builds, container logs, and compose up.

## Changes
- **Stream module**: Core streaming infrastructure with OutputLine enum and StreamResult type
- **StreamableCommand trait**: Async trait for commands that support streaming
- **Command implementations**: Added streaming to BuildCommand, RunCommand, and LogsCommand
- **Stream handlers**: Utility functions for common patterns (print, filter, tee, with_prefix)
- **Dual APIs**: Both callback-based and channel-based streaming for flexibility
- **Example**: Comprehensive example showing various streaming patterns

## Implementation Details

### Core Components
- `OutputLine` enum to differentiate stdout/stderr
- `StreamResult` with exit code and accumulated output
- `StreamableCommand` trait with stream() and stream_channel() methods
- `StreamHandler` utilities for common use cases

### Supported Commands
- **BuildCommand**: Stream build progress in real-time
- **RunCommand**: Stream container output (non-detached only)
- **LogsCommand**: Stream logs with follow option

## Usage Example
```rust
use docker_wrapper::{BuildCommand, StreamHandler};

// Stream build output to console
let result = BuildCommand::new(".")
    .tag("myapp:latest")
    .stream(StreamHandler::print())
    .await?;

// Custom handler for filtering
let result = LogsCommand::new("mycontainer")
    .follow()
    .stream(|line| {
        if let OutputLine::Stderr(err) = line {
            eprintln!("Error: {}", err);
        }
    })
    .await?;
```

## Testing
- Example runs successfully: `cargo run --example streaming`
- All tests pass: `cargo test --all-features`
- No clippy warnings: `cargo clippy --all-features -- -D warnings`

## Breaking Changes
None - streaming is an additive feature that doesn't affect existing APIs.

## Future Work
- Add streaming to more commands (pull, push, compose up)
- Progress bar integration for build/pull operations
- Structured parsing of build output

## Related Issues
- Closes #39 - Add support for streaming command output

## Checklist
- [x] Tests pass
- [x] Code is formatted
- [x] Clippy warnings resolved
- [x] Example provided
- [x] Documentation added
- [x] Non-breaking change