### PR TITLE
fix: Release-please permissions and label creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  issues: write
 
 jobs:
   release-please:
@@ -27,6 +28,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-labeling: true
 
       # Generate changelog with git-cliff after release
       - name: Checkout code


### PR DESCRIPTION
## Summary
Fixes the release-please workflow permission error: 'You do not have permission to create labels on this repository'

## Changes
- Add `issues: write` permission to the workflow
- Add `skip-labeling: true` to release-please action

## Approach
Using a two-pronged approach:
1. Grant the necessary permission for label operations
2. Skip label creation entirely as a fallback

This ensures the workflow will work regardless of whether labels are needed.

## Testing
The fix will be validated on the next merge to main when release-please runs.