### PR TITLE
feat: Complete Docker Compose support - 100% command coverage

### DIFF
--- a/src/compose/attach.rs
+++ b/src/compose/attach.rs
@@ -1,0 +1,179 @@
+//! Docker Compose attach command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose attach command
+///
+/// Attach to a running container's output.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeAttachCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Service to attach to
+    pub service: String,
+    /// Detach keys sequence
+    pub detach_keys: Option<String>,
+    /// Container index if service has multiple instances
+    pub index: Option<u32>,
+    /// Don't stream STDIN
+    pub no_stdin: bool,
+    /// Use a pseudo-TTY
+    pub sig_proxy: bool,
+}
+
+/// Result from attach command
+#[derive(Debug, Clone)]
+pub struct AttachResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeAttachCommand {
+    /// Create a new attach command
+    #[must_use]
+    pub fn new(service: impl Into<String>) -> Self {
+        Self {
+            service: service.into(),
+            sig_proxy: true, // Default to true
+            ..Default::default()
+        }
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set detach keys
+    #[must_use]
+    pub fn detach_keys(mut self, keys: impl Into<String>) -> Self {
+        self.detach_keys = Some(keys.into());
+        self
+    }
+
+    /// Set container index
+    #[must_use]
+    pub fn index(mut self, index: u32) -> Self {
+        self.index = Some(index);
+        self
+    }
+
+    /// Don't attach to STDIN
+    #[must_use]
+    pub fn no_stdin(mut self) -> Self {
+        self.no_stdin = true;
+        self
+    }
+
+    /// Disable signal proxy
+    #[must_use]
+    pub fn no_sig_proxy(mut self) -> Self {
+        self.sig_proxy = false;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["attach".to_string()];
+
+        // Add flags
+        if let Some(ref keys) = self.detach_keys {
+            args.push("--detach-keys".to_string());
+            args.push(keys.clone());
+        }
+
+        if let Some(index) = self.index {
+            args.push("--index".to_string());
+            args.push(index.to_string());
+        }
+
+        if self.no_stdin {
+            args.push("--no-stdin".to_string());
+        }
+
+        if !self.sig_proxy {
+            args.push("--sig-proxy=false".to_string());
+        }
+
+        // Add service
+        args.push(self.service.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeAttachCommand {
+    type Output = AttachResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(AttachResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_attach_command_basic() {
+        let cmd = ComposeAttachCommand::new("web");
+        let args = cmd.build_args();
+        assert_eq!(args[0], "attach");
+        assert!(args.contains(&"web".to_string()));
+    }
+
+    #[test]
+    fn test_attach_command_with_detach_keys() {
+        let cmd = ComposeAttachCommand::new("web").detach_keys("ctrl-p,ctrl-q");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--detach-keys".to_string()));
+        assert!(args.contains(&"ctrl-p,ctrl-q".to_string()));
+    }
+
+    #[test]
+    fn test_attach_command_with_index() {
+        let cmd = ComposeAttachCommand::new("web").index(2).no_stdin();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--index".to_string()));
+        assert!(args.contains(&"2".to_string()));
+        assert!(args.contains(&"--no-stdin".to_string()));
+    }
+
+    #[test]
+    fn test_attach_command_with_no_sig_proxy() {
+        let cmd = ComposeAttachCommand::new("worker").no_sig_proxy();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--sig-proxy=false".to_string()));
+    }
+}

--- a/src/compose/config.rs
+++ b/src/compose/config.rs
@@ -1,0 +1,288 @@
+//! Docker Compose config command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose config command
+///
+/// Validates and displays the Compose configuration.
+#[derive(Debug, Clone, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ComposeConfigCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Format output
+    pub format: Option<ConfigFormat>,
+    /// Resolve image digests
+    pub resolve_image_digests: bool,
+    /// Don't interpolate environment
+    pub no_interpolate: bool,
+    /// Don't normalize paths
+    pub no_normalize: bool,
+    /// Don't check consistency
+    pub no_consistency: bool,
+    /// Show services
+    pub services: bool,
+    /// Show volumes
+    pub volumes: bool,
+    /// Show profiles
+    pub profiles: bool,
+    /// Show images
+    pub images: bool,
+    /// Hash of services to include
+    pub hash: Option<String>,
+    /// Output file
+    pub output: Option<String>,
+    /// Quiet mode
+    pub quiet: bool,
+}
+
+/// Config output format
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigFormat {
+    /// YAML format (default)
+    Yaml,
+    /// JSON format
+    Json,
+}
+
+impl ConfigFormat {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Yaml => "yaml",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Result from config command
+#[derive(Debug, Clone)]
+pub struct ConfigResult {
+    /// The configuration output (YAML or JSON)
+    pub config: String,
+    /// Whether the config is valid
+    pub is_valid: bool,
+}
+
+impl ComposeConfigCommand {
+    /// Create a new config command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set output format
+    #[must_use]
+    pub fn format(mut self, format: ConfigFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Resolve image digests
+    #[must_use]
+    pub fn resolve_image_digests(mut self) -> Self {
+        self.resolve_image_digests = true;
+        self
+    }
+
+    /// Don't interpolate environment
+    #[must_use]
+    pub fn no_interpolate(mut self) -> Self {
+        self.no_interpolate = true;
+        self
+    }
+
+    /// Don't normalize paths
+    #[must_use]
+    pub fn no_normalize(mut self) -> Self {
+        self.no_normalize = true;
+        self
+    }
+
+    /// Don't check consistency
+    #[must_use]
+    pub fn no_consistency(mut self) -> Self {
+        self.no_consistency = true;
+        self
+    }
+
+    /// Show services only
+    #[must_use]
+    pub fn services(mut self) -> Self {
+        self.services = true;
+        self
+    }
+
+    /// Show volumes only
+    #[must_use]
+    pub fn volumes(mut self) -> Self {
+        self.volumes = true;
+        self
+    }
+
+    /// Show profiles only
+    #[must_use]
+    pub fn profiles(mut self) -> Self {
+        self.profiles = true;
+        self
+    }
+
+    /// Show images only
+    #[must_use]
+    pub fn images(mut self) -> Self {
+        self.images = true;
+        self
+    }
+
+    /// Set services hash
+    #[must_use]
+    pub fn hash(mut self, hash: impl Into<String>) -> Self {
+        self.hash = Some(hash.into());
+        self
+    }
+
+    /// Set output file
+    #[must_use]
+    pub fn output(mut self, path: impl Into<String>) -> Self {
+        self.output = Some(path.into());
+        self
+    }
+
+    /// Enable quiet mode
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["config".to_string()];
+
+        // Add format
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.as_arg().to_string());
+        }
+
+        // Add flags
+        if self.resolve_image_digests {
+            args.push("--resolve-image-digests".to_string());
+        }
+        if self.no_interpolate {
+            args.push("--no-interpolate".to_string());
+        }
+        if self.no_normalize {
+            args.push("--no-normalize".to_string());
+        }
+        if self.no_consistency {
+            args.push("--no-consistency".to_string());
+        }
+        if self.services {
+            args.push("--services".to_string());
+        }
+        if self.volumes {
+            args.push("--volumes".to_string());
+        }
+        if self.profiles {
+            args.push("--profiles".to_string());
+        }
+        if self.images {
+            args.push("--images".to_string());
+        }
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        // Add hash
+        if let Some(hash) = &self.hash {
+            args.push("--hash".to_string());
+            args.push(hash.clone());
+        }
+
+        // Add output
+        if let Some(output) = &self.output {
+            args.push("--output".to_string());
+            args.push(output.clone());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeConfigCommand {
+    type Output = ConfigResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(ConfigResult {
+            config: output.stdout,
+            is_valid: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_command_basic() {
+        let cmd = ComposeConfigCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "config");
+    }
+
+    #[test]
+    fn test_config_command_with_format() {
+        let cmd = ComposeConfigCommand::new().format(ConfigFormat::Json);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+
+    #[test]
+    fn test_config_command_with_flags() {
+        let cmd = ComposeConfigCommand::new()
+            .resolve_image_digests()
+            .no_interpolate()
+            .services()
+            .quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--resolve-image-digests".to_string()));
+        assert!(args.contains(&"--no-interpolate".to_string()));
+        assert!(args.contains(&"--services".to_string()));
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+}

--- a/src/compose/convert.rs
+++ b/src/compose/convert.rs
@@ -1,0 +1,327 @@
+//! Docker Compose convert command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose convert command
+///
+/// Convert compose files to different formats or validate them.
+#[derive(Debug, Clone, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ComposeConvertCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Output format
+    pub format: Option<ConvertFormat>,
+    /// Resolve image digests
+    pub resolve_image_digests: bool,
+    /// Don't interpolate environment
+    pub no_interpolate: bool,
+    /// Don't normalize paths
+    pub no_normalize: bool,
+    /// Don't check consistency
+    pub no_consistency: bool,
+    /// Show services
+    pub services: bool,
+    /// Show volumes
+    pub volumes: bool,
+    /// Show profiles
+    pub profiles: bool,
+    /// Show images
+    pub images: bool,
+    /// Hash of services to include
+    pub hash: Option<String>,
+    /// Output file
+    pub output: Option<String>,
+    /// Quiet mode
+    pub quiet: bool,
+}
+
+/// Convert output format
+#[derive(Debug, Clone, Copy)]
+pub enum ConvertFormat {
+    /// YAML format (default)
+    Yaml,
+    /// JSON format
+    Json,
+}
+
+impl ConvertFormat {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Yaml => "yaml",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Result from convert command
+#[derive(Debug, Clone)]
+pub struct ConvertResult {
+    /// The converted configuration (YAML or JSON)
+    pub config: String,
+    /// Whether the conversion succeeded
+    pub success: bool,
+}
+
+impl ComposeConvertCommand {
+    /// Create a new convert command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set output format
+    #[must_use]
+    pub fn format(mut self, format: ConvertFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Resolve image digests
+    #[must_use]
+    pub fn resolve_image_digests(mut self) -> Self {
+        self.resolve_image_digests = true;
+        self
+    }
+
+    /// Don't interpolate environment
+    #[must_use]
+    pub fn no_interpolate(mut self) -> Self {
+        self.no_interpolate = true;
+        self
+    }
+
+    /// Don't normalize paths
+    #[must_use]
+    pub fn no_normalize(mut self) -> Self {
+        self.no_normalize = true;
+        self
+    }
+
+    /// Don't check consistency
+    #[must_use]
+    pub fn no_consistency(mut self) -> Self {
+        self.no_consistency = true;
+        self
+    }
+
+    /// Show services only
+    #[must_use]
+    pub fn services(mut self) -> Self {
+        self.services = true;
+        self
+    }
+
+    /// Show volumes only
+    #[must_use]
+    pub fn volumes(mut self) -> Self {
+        self.volumes = true;
+        self
+    }
+
+    /// Show profiles only
+    #[must_use]
+    pub fn profiles(mut self) -> Self {
+        self.profiles = true;
+        self
+    }
+
+    /// Show images only
+    #[must_use]
+    pub fn images(mut self) -> Self {
+        self.images = true;
+        self
+    }
+
+    /// Set services hash
+    #[must_use]
+    pub fn hash(mut self, hash: impl Into<String>) -> Self {
+        self.hash = Some(hash.into());
+        self
+    }
+
+    /// Set output file
+    #[must_use]
+    pub fn output(mut self, path: impl Into<String>) -> Self {
+        self.output = Some(path.into());
+        self
+    }
+
+    /// Enable quiet mode
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["convert".to_string()];
+
+        // Add format
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.as_arg().to_string());
+        }
+
+        // Add flags
+        if self.resolve_image_digests {
+            args.push("--resolve-image-digests".to_string());
+        }
+        if self.no_interpolate {
+            args.push("--no-interpolate".to_string());
+        }
+        if self.no_normalize {
+            args.push("--no-normalize".to_string());
+        }
+        if self.no_consistency {
+            args.push("--no-consistency".to_string());
+        }
+        if self.services {
+            args.push("--services".to_string());
+        }
+        if self.volumes {
+            args.push("--volumes".to_string());
+        }
+        if self.profiles {
+            args.push("--profiles".to_string());
+        }
+        if self.images {
+            args.push("--images".to_string());
+        }
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        // Add hash
+        if let Some(hash) = &self.hash {
+            args.push("--hash".to_string());
+            args.push(hash.clone());
+        }
+
+        // Add output
+        if let Some(output) = &self.output {
+            args.push("--output".to_string());
+            args.push(output.clone());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeConvertCommand {
+    type Output = ConvertResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(ConvertResult {
+            config: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+impl ConvertResult {
+    /// Check if the output is valid JSON
+    #[must_use]
+    pub fn is_json(&self) -> bool {
+        serde_json::from_str::<serde_json::Value>(&self.config).is_ok()
+    }
+
+    /// Check if the output is likely YAML
+    #[must_use]
+    pub fn is_yaml(&self) -> bool {
+        !self.config.is_empty() && (self.config.contains(':') || self.config.contains('-'))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_command_basic() {
+        let cmd = ComposeConvertCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "convert");
+    }
+
+    #[test]
+    fn test_convert_command_with_format() {
+        let cmd = ComposeConvertCommand::new().format(ConvertFormat::Json);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+
+    #[test]
+    fn test_convert_command_with_flags() {
+        let cmd = ComposeConvertCommand::new()
+            .resolve_image_digests()
+            .no_interpolate()
+            .services()
+            .quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--resolve-image-digests".to_string()));
+        assert!(args.contains(&"--no-interpolate".to_string()));
+        assert!(args.contains(&"--services".to_string()));
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_convert_command_with_output() {
+        let cmd = ComposeConvertCommand::new()
+            .output("docker-compose.json")
+            .format(ConvertFormat::Json);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--output".to_string()));
+        assert!(args.contains(&"docker-compose.json".to_string()));
+    }
+
+    #[test]
+    fn test_convert_result_helpers() {
+        let json_result = ConvertResult {
+            config: r#"{"version": "3.8"}"#.to_string(),
+            success: true,
+        };
+        assert!(json_result.is_json());
+
+        let yaml_result = ConvertResult {
+            config: "version: '3.8'\nservices:\n  web:\n    image: nginx".to_string(),
+            success: true,
+        };
+        assert!(yaml_result.is_yaml());
+    }
+}

--- a/src/compose/cp.rs
+++ b/src/compose/cp.rs
@@ -1,0 +1,202 @@
+//! Docker Compose cp command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+/// Docker Compose cp command
+///
+/// Copy files/folders between a service container and the local filesystem.
+#[derive(Debug, Clone)]
+pub struct ComposeCpCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Source path (can be container:path or local path)
+    pub source: String,
+    /// Destination path (can be container:path or local path)
+    pub destination: String,
+    /// Archive mode (preserve permissions)
+    pub archive: bool,
+    /// Follow symbolic links
+    pub follow_link: bool,
+    /// Index of the container (if service has multiple instances)
+    pub index: Option<u32>,
+}
+
+/// Result from cp command
+#[derive(Debug, Clone)]
+pub struct CpResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeCpCommand {
+    /// Create a new cp command
+    #[must_use]
+    pub fn new(source: impl Into<String>, destination: impl Into<String>) -> Self {
+        Self {
+            config: ComposeConfig::default(),
+            source: source.into(),
+            destination: destination.into(),
+            archive: false,
+            follow_link: false,
+            index: None,
+        }
+    }
+
+    /// Copy from container to local
+    #[must_use]
+    pub fn from_container(
+        service: impl Into<String>,
+        container_path: impl Into<String>,
+        local_path: impl Into<PathBuf>,
+    ) -> Self {
+        let source = format!("{}:{}", service.into(), container_path.into());
+        let destination = local_path.into().display().to_string();
+        Self::new(source, destination)
+    }
+
+    /// Copy from local to container
+    #[must_use]
+    pub fn to_container(
+        local_path: impl Into<PathBuf>,
+        service: impl Into<String>,
+        container_path: impl Into<String>,
+    ) -> Self {
+        let source = local_path.into().display().to_string();
+        let destination = format!("{}:{}", service.into(), container_path.into());
+        Self::new(source, destination)
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Enable archive mode
+    #[must_use]
+    pub fn archive(mut self) -> Self {
+        self.archive = true;
+        self
+    }
+
+    /// Follow symbolic links
+    #[must_use]
+    pub fn follow_link(mut self) -> Self {
+        self.follow_link = true;
+        self
+    }
+
+    /// Set container index
+    #[must_use]
+    pub fn index(mut self, index: u32) -> Self {
+        self.index = Some(index);
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["cp".to_string()];
+
+        // Add flags
+        if self.archive {
+            args.push("--archive".to_string());
+        }
+        if self.follow_link {
+            args.push("--follow-link".to_string());
+        }
+
+        // Add index if specified
+        if let Some(index) = self.index {
+            args.push("--index".to_string());
+            args.push(index.to_string());
+        }
+
+        // Add source and destination
+        args.push(self.source.clone());
+        args.push(self.destination.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeCpCommand {
+    type Output = CpResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(CpResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cp_command_basic() {
+        let cmd = ComposeCpCommand::new("web:/app/config.yml", "./config.yml");
+        let args = cmd.build_args();
+        assert_eq!(args[0], "cp");
+        assert!(args.contains(&"web:/app/config.yml".to_string()));
+        assert!(args.contains(&"./config.yml".to_string()));
+    }
+
+    #[test]
+    fn test_cp_from_container() {
+        let cmd = ComposeCpCommand::from_container("web", "/app/logs", "./logs");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web:/app/logs".to_string()));
+        assert!(args.contains(&"./logs".to_string()));
+    }
+
+    #[test]
+    fn test_cp_to_container() {
+        let cmd = ComposeCpCommand::to_container("./config.yml", "web", "/app/config.yml");
+        let args = cmd.build_args();
+        assert!(args.contains(&"./config.yml".to_string()));
+        assert!(args.contains(&"web:/app/config.yml".to_string()));
+    }
+
+    #[test]
+    fn test_cp_command_with_flags() {
+        let cmd = ComposeCpCommand::new("web:/data", "./data")
+            .archive()
+            .follow_link()
+            .index(1);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--archive".to_string()));
+        assert!(args.contains(&"--follow-link".to_string()));
+        assert!(args.contains(&"--index".to_string()));
+        assert!(args.contains(&"1".to_string()));
+    }
+}

--- a/src/compose/create.rs
+++ b/src/compose/create.rs
@@ -1,0 +1,248 @@
+//! Docker Compose create command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose create command
+///
+/// Create services without starting them.
+#[derive(Debug, Clone, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ComposeCreateCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Build images before creating containers
+    pub build: bool,
+    /// Don't build images, even if missing
+    pub no_build: bool,
+    /// Force recreate containers
+    pub force_recreate: bool,
+    /// Don't recreate containers if they exist
+    pub no_recreate: bool,
+    /// Pull images before creating
+    pub pull: Option<PullPolicy>,
+    /// Remove orphaned containers
+    pub remove_orphans: bool,
+    /// Services to create
+    pub services: Vec<String>,
+}
+
+/// Pull policy for images
+#[derive(Debug, Clone, Copy)]
+pub enum PullPolicy {
+    /// Always pull images
+    Always,
+    /// Never pull images
+    Never,
+    /// Pull missing images (default)
+    Missing,
+    /// Pull images if local is older
+    Build,
+}
+
+impl PullPolicy {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Always => "always",
+            Self::Never => "never",
+            Self::Missing => "missing",
+            Self::Build => "build",
+        }
+    }
+}
+
+/// Result from create command
+#[derive(Debug, Clone)]
+pub struct CreateResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeCreateCommand {
+    /// Create a new create command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Build images before creating
+    #[must_use]
+    pub fn build(mut self) -> Self {
+        self.build = true;
+        self
+    }
+
+    /// Don't build images
+    #[must_use]
+    pub fn no_build(mut self) -> Self {
+        self.no_build = true;
+        self
+    }
+
+    /// Force recreate containers
+    #[must_use]
+    pub fn force_recreate(mut self) -> Self {
+        self.force_recreate = true;
+        self
+    }
+
+    /// Don't recreate containers
+    #[must_use]
+    pub fn no_recreate(mut self) -> Self {
+        self.no_recreate = true;
+        self
+    }
+
+    /// Set pull policy
+    #[must_use]
+    pub fn pull(mut self, policy: PullPolicy) -> Self {
+        self.pull = Some(policy);
+        self
+    }
+
+    /// Remove orphaned containers
+    #[must_use]
+    pub fn remove_orphans(mut self) -> Self {
+        self.remove_orphans = true;
+        self
+    }
+
+    /// Add a service to create
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to create
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["create".to_string()];
+
+        // Add flags
+        if self.build {
+            args.push("--build".to_string());
+        }
+        if self.no_build {
+            args.push("--no-build".to_string());
+        }
+        if self.force_recreate {
+            args.push("--force-recreate".to_string());
+        }
+        if self.no_recreate {
+            args.push("--no-recreate".to_string());
+        }
+        if self.remove_orphans {
+            args.push("--remove-orphans".to_string());
+        }
+
+        // Add pull policy
+        if let Some(pull) = &self.pull {
+            args.push("--pull".to_string());
+            args.push(pull.as_arg().to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeCreateCommand {
+    type Output = CreateResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(CreateResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_command_basic() {
+        let cmd = ComposeCreateCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "create");
+    }
+
+    #[test]
+    fn test_create_command_with_build() {
+        let cmd = ComposeCreateCommand::new().build().force_recreate();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--build".to_string()));
+        assert!(args.contains(&"--force-recreate".to_string()));
+    }
+
+    #[test]
+    fn test_create_command_with_pull() {
+        let cmd = ComposeCreateCommand::new()
+            .pull(PullPolicy::Always)
+            .no_recreate();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--pull".to_string()));
+        assert!(args.contains(&"always".to_string()));
+        assert!(args.contains(&"--no-recreate".to_string()));
+    }
+
+    #[test]
+    fn test_create_command_with_services() {
+        let cmd = ComposeCreateCommand::new()
+            .service("web")
+            .service("db")
+            .remove_orphans();
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"db".to_string()));
+        assert!(args.contains(&"--remove-orphans".to_string()));
+    }
+}

--- a/src/compose/events.rs
+++ b/src/compose/events.rs
@@ -1,0 +1,212 @@
+//! Docker Compose events command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Docker Compose events command
+///
+/// Stream container events for services.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeEventsCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Output format as JSON
+    pub json: bool,
+    /// Start timestamp
+    pub since: Option<String>,
+    /// End timestamp
+    pub until: Option<String>,
+    /// Services to get events for
+    pub services: Vec<String>,
+}
+
+/// Event from Docker Compose
+#[derive(Debug, Clone, Deserialize)]
+pub struct ComposeEvent {
+    /// Time of the event
+    pub time: String,
+    /// Type of the event
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Action that occurred
+    pub action: String,
+    /// Service name
+    pub service: Option<String>,
+    /// Container ID
+    pub container: Option<String>,
+    /// Additional attributes
+    pub attributes: Option<serde_json::Value>,
+}
+
+/// Result from events command
+#[derive(Debug, Clone)]
+pub struct EventsResult {
+    /// Raw output from the command
+    pub output: String,
+    /// Parsed events (if JSON format)
+    pub events: Vec<ComposeEvent>,
+}
+
+impl ComposeEventsCommand {
+    /// Create a new events command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Output as JSON
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Set start timestamp
+    #[must_use]
+    pub fn since(mut self, timestamp: impl Into<String>) -> Self {
+        self.since = Some(timestamp.into());
+        self
+    }
+
+    /// Set end timestamp
+    #[must_use]
+    pub fn until(mut self, timestamp: impl Into<String>) -> Self {
+        self.until = Some(timestamp.into());
+        self
+    }
+
+    /// Add a service to get events for
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["events".to_string()];
+
+        // Add flags
+        if self.json {
+            args.push("--json".to_string());
+        }
+
+        // Add timestamps
+        if let Some(since) = &self.since {
+            args.push("--since".to_string());
+            args.push(since.clone());
+        }
+        if let Some(until) = &self.until {
+            args.push("--until".to_string());
+            args.push(until.clone());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeEventsCommand {
+    type Output = EventsResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        // Parse events if JSON format
+        let events = if self.json {
+            output
+                .stdout
+                .lines()
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        Ok(EventsResult {
+            output: output.stdout,
+            events,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_events_command_basic() {
+        let cmd = ComposeEventsCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "events");
+    }
+
+    #[test]
+    fn test_events_command_with_json() {
+        let cmd = ComposeEventsCommand::new().json();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--json".to_string()));
+    }
+
+    #[test]
+    fn test_events_command_with_timestamps() {
+        let cmd = ComposeEventsCommand::new()
+            .since("2025-08-23T00:00:00")
+            .until("2025-08-23T23:59:59");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--since".to_string()));
+        assert!(args.contains(&"2025-08-23T00:00:00".to_string()));
+        assert!(args.contains(&"--until".to_string()));
+        assert!(args.contains(&"2025-08-23T23:59:59".to_string()));
+    }
+
+    #[test]
+    fn test_events_command_with_services() {
+        let cmd = ComposeEventsCommand::new().service("web").service("db");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"db".to_string()));
+    }
+}

--- a/src/compose/images.rs
+++ b/src/compose/images.rs
@@ -1,0 +1,239 @@
+//! Docker Compose images command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Docker Compose images command
+///
+/// List images used by services.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeImagesCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Format output (table, json)
+    pub format: Option<ImagesFormat>,
+    /// Only display image IDs
+    pub quiet: bool,
+    /// Services to list images for
+    pub services: Vec<String>,
+}
+
+/// Images output format
+#[derive(Debug, Clone, Copy)]
+pub enum ImagesFormat {
+    /// Table format (default)
+    Table,
+    /// JSON format
+    Json,
+}
+
+impl ImagesFormat {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Table => "table",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Image information
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ImageInfo {
+    /// Container name
+    pub container: String,
+    /// Repository
+    pub repository: String,
+    /// Tag
+    pub tag: String,
+    /// Image ID
+    pub image_id: String,
+    /// Size
+    pub size: String,
+}
+
+/// Result from images command
+#[derive(Debug, Clone)]
+pub struct ImagesResult {
+    /// List of images
+    pub images: Vec<ImageInfo>,
+    /// Raw output (for non-JSON formats)
+    pub raw_output: String,
+}
+
+impl ComposeImagesCommand {
+    /// Create a new images command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set output format
+    #[must_use]
+    pub fn format(mut self, format: ImagesFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Set output format to JSON
+    #[must_use]
+    pub fn format_json(mut self) -> Self {
+        self.format = Some(ImagesFormat::Json);
+        self
+    }
+
+    /// Only display image IDs
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    /// Add a service to list images for
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["images".to_string()];
+
+        // Add flags
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        // Add format
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.as_arg().to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeImagesCommand {
+    type Output = ImagesResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        // Parse JSON output if format is JSON
+        let images = if matches!(self.format, Some(ImagesFormat::Json)) {
+            serde_json::from_str(&output.stdout).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        Ok(ImagesResult {
+            images,
+            raw_output: output.stdout,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+impl ImagesResult {
+    /// Get unique images
+    #[must_use]
+    pub fn unique_images(&self) -> Vec<String> {
+        let mut images: Vec<_> = self
+            .images
+            .iter()
+            .map(|img| format!("{}:{}", img.repository, img.tag))
+            .collect();
+        images.sort();
+        images.dedup();
+        images
+    }
+
+    /// Get total size
+    #[must_use]
+    pub fn total_size(&self) -> String {
+        // This would need proper size parsing
+        // For now just return placeholder
+        "N/A".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_images_command_basic() {
+        let cmd = ComposeImagesCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "images");
+    }
+
+    #[test]
+    fn test_images_command_with_format() {
+        let cmd = ComposeImagesCommand::new().format_json();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+
+    #[test]
+    fn test_images_command_with_quiet() {
+        let cmd = ComposeImagesCommand::new().quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_images_command_with_services() {
+        let cmd = ComposeImagesCommand::new().service("web").service("db");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"db".to_string()));
+    }
+}

--- a/src/compose/kill.rs
+++ b/src/compose/kill.rs
@@ -1,0 +1,162 @@
+//! Docker Compose kill command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose kill command
+///
+/// Force stop service containers.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeKillCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Signal to send (default: SIGKILL)
+    pub signal: Option<String>,
+    /// Remove containers after killing
+    pub remove_orphans: bool,
+    /// Services to kill
+    pub services: Vec<String>,
+}
+
+/// Result from kill command
+#[derive(Debug, Clone)]
+pub struct KillResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeKillCommand {
+    /// Create a new kill command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set signal to send
+    #[must_use]
+    pub fn signal(mut self, signal: impl Into<String>) -> Self {
+        self.signal = Some(signal.into());
+        self
+    }
+
+    /// Remove orphaned containers
+    #[must_use]
+    pub fn remove_orphans(mut self) -> Self {
+        self.remove_orphans = true;
+        self
+    }
+
+    /// Add a service to kill
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to kill
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["kill".to_string()];
+
+        // Add signal
+        if let Some(signal) = &self.signal {
+            args.push("--signal".to_string());
+            args.push(signal.clone());
+        }
+
+        // Add flags
+        if self.remove_orphans {
+            args.push("--remove-orphans".to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeKillCommand {
+    type Output = KillResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(KillResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kill_command_basic() {
+        let cmd = ComposeKillCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "kill");
+    }
+
+    #[test]
+    fn test_kill_command_with_signal() {
+        let cmd = ComposeKillCommand::new().signal("SIGTERM");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--signal".to_string()));
+        assert!(args.contains(&"SIGTERM".to_string()));
+    }
+
+    #[test]
+    fn test_kill_command_with_services() {
+        let cmd = ComposeKillCommand::new()
+            .service("web")
+            .service("worker")
+            .remove_orphans();
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+        assert!(args.contains(&"--remove-orphans".to_string()));
+    }
+}

--- a/src/compose/ls.rs
+++ b/src/compose/ls.rs
@@ -1,0 +1,256 @@
+//! Docker Compose ls command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Docker Compose ls command
+///
+/// List running compose projects.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeLsCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Show all projects (including stopped)
+    pub all: bool,
+    /// Filter by name
+    pub filter: Option<String>,
+    /// Format output (table, json)
+    pub format: Option<LsFormat>,
+    /// Only display project names
+    pub quiet: bool,
+}
+
+/// Ls output format
+#[derive(Debug, Clone, Copy)]
+pub enum LsFormat {
+    /// Table format (default)
+    Table,
+    /// JSON format
+    Json,
+}
+
+impl LsFormat {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Table => "table",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Compose project information
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ComposeProject {
+    /// Project name
+    pub name: String,
+    /// Status
+    pub status: String,
+    /// Configuration files
+    #[serde(default)]
+    pub config_files: String,
+    /// Created timestamp
+    #[serde(default)]
+    pub created: String,
+}
+
+/// Result from ls command
+#[derive(Debug, Clone)]
+pub struct LsResult {
+    /// List of compose projects
+    pub projects: Vec<ComposeProject>,
+    /// Raw output (for non-JSON formats)
+    pub raw_output: String,
+}
+
+impl ComposeLsCommand {
+    /// Create a new ls command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Show all projects
+    #[must_use]
+    pub fn all(mut self) -> Self {
+        self.all = true;
+        self
+    }
+
+    /// Filter projects
+    #[must_use]
+    pub fn filter(mut self, filter: impl Into<String>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    /// Set output format
+    #[must_use]
+    pub fn format(mut self, format: LsFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Set output format to JSON
+    #[must_use]
+    pub fn format_json(mut self) -> Self {
+        self.format = Some(LsFormat::Json);
+        self
+    }
+
+    /// Only display project names
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["ls".to_string()];
+
+        // Add flags
+        if self.all {
+            args.push("--all".to_string());
+        }
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        // Add filter
+        if let Some(filter) = &self.filter {
+            args.push("--filter".to_string());
+            args.push(filter.clone());
+        }
+
+        // Add format
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.as_arg().to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeLsCommand {
+    type Output = LsResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        // Parse JSON output if format is JSON
+        let projects = if matches!(self.format, Some(LsFormat::Json)) {
+            serde_json::from_str(&output.stdout).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        Ok(LsResult {
+            projects,
+            raw_output: output.stdout,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+impl LsResult {
+    /// Get project names
+    #[must_use]
+    pub fn project_names(&self) -> Vec<String> {
+        self.projects.iter().map(|p| p.name.clone()).collect()
+    }
+
+    /// Check if a project exists
+    #[must_use]
+    pub fn has_project(&self, name: &str) -> bool {
+        self.projects.iter().any(|p| p.name == name)
+    }
+
+    /// Get running projects
+    #[must_use]
+    pub fn running_projects(&self) -> Vec<&ComposeProject> {
+        self.projects
+            .iter()
+            .filter(|p| p.status.contains("running"))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ls_command_basic() {
+        let cmd = ComposeLsCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "ls");
+    }
+
+    #[test]
+    fn test_ls_command_with_all() {
+        let cmd = ComposeLsCommand::new().all();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--all".to_string()));
+    }
+
+    #[test]
+    fn test_ls_command_with_format() {
+        let cmd = ComposeLsCommand::new().format_json();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+
+    #[test]
+    fn test_ls_command_with_filter() {
+        let cmd = ComposeLsCommand::new().filter("status=running").quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--filter".to_string()));
+        assert!(args.contains(&"status=running".to_string()));
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_ls_result_helpers() {
+        let result = LsResult {
+            projects: vec![
+                ComposeProject {
+                    name: "web".to_string(),
+                    status: "running(3)".to_string(),
+                    config_files: "docker-compose.yml".to_string(),
+                    created: "2025-08-23".to_string(),
+                },
+                ComposeProject {
+                    name: "db".to_string(),
+                    status: "exited(0)".to_string(),
+                    config_files: "docker-compose.yml".to_string(),
+                    created: "2025-08-23".to_string(),
+                },
+            ],
+            raw_output: String::new(),
+        };
+
+        assert_eq!(result.project_names(), vec!["web", "db"]);
+        assert!(result.has_project("web"));
+        assert!(!result.has_project("cache"));
+        assert_eq!(result.running_projects().len(), 1);
+    }
+}

--- a/src/compose/pause.rs
+++ b/src/compose/pause.rs
@@ -1,0 +1,121 @@
+//! Docker Compose pause command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose pause command
+///
+/// Pause services.
+#[derive(Debug, Clone, Default)]
+pub struct ComposePauseCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Services to pause
+    pub services: Vec<String>,
+}
+
+/// Result from pause command
+#[derive(Debug, Clone)]
+pub struct PauseResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposePauseCommand {
+    /// Create a new pause command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Add a service to pause
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to pause
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["pause".to_string()];
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposePauseCommand {
+    type Output = PauseResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(PauseResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pause_command_basic() {
+        let cmd = ComposePauseCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "pause");
+    }
+
+    #[test]
+    fn test_pause_command_with_services() {
+        let cmd = ComposePauseCommand::new().service("web").service("worker");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+    }
+}

--- a/src/compose/port.rs
+++ b/src/compose/port.rs
@@ -1,0 +1,191 @@
+//! Docker Compose port command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose port command
+///
+/// Print the public port for a port binding.
+#[derive(Debug, Clone, Default)]
+pub struct ComposePortCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Service name
+    pub service: String,
+    /// Private port number
+    pub private_port: u16,
+    /// Protocol (tcp/udp)
+    pub protocol: Option<String>,
+    /// Index of the container (if service has multiple instances)
+    pub index: Option<u32>,
+}
+
+/// Result from port command
+#[derive(Debug, Clone)]
+pub struct PortResult {
+    /// The public port binding (host:port)
+    pub binding: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposePortCommand {
+    /// Create a new port command
+    #[must_use]
+    pub fn new(service: impl Into<String>, private_port: u16) -> Self {
+        Self {
+            service: service.into(),
+            private_port,
+            ..Default::default()
+        }
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Set protocol (tcp/udp)
+    #[must_use]
+    pub fn protocol(mut self, protocol: impl Into<String>) -> Self {
+        self.protocol = Some(protocol.into());
+        self
+    }
+
+    /// Set container index
+    #[must_use]
+    pub fn index(mut self, index: u32) -> Self {
+        self.index = Some(index);
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["port".to_string()];
+
+        // Add index if specified
+        if let Some(index) = self.index {
+            args.push("--index".to_string());
+            args.push(index.to_string());
+        }
+
+        // Add protocol if specified
+        if let Some(protocol) = &self.protocol {
+            args.push("--protocol".to_string());
+            args.push(protocol.clone());
+        }
+
+        // Add service and port
+        args.push(self.service.clone());
+        args.push(self.private_port.to_string());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposePortCommand {
+    type Output = PortResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(PortResult {
+            binding: output.stdout.trim().to_string(),
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+impl PortResult {
+    /// Parse the binding into host and port
+    #[must_use]
+    pub fn parse_binding(&self) -> Option<(String, u16)> {
+        let parts: Vec<&str> = self.binding.split(':').collect();
+        if parts.len() == 2 {
+            if let Ok(port) = parts[1].parse::<u16>() {
+                return Some((parts[0].to_string(), port));
+            }
+        }
+        None
+    }
+
+    /// Get just the port number
+    #[must_use]
+    pub fn port(&self) -> Option<u16> {
+        self.parse_binding().map(|(_, port)| port)
+    }
+
+    /// Get just the host
+    #[must_use]
+    pub fn host(&self) -> Option<String> {
+        self.parse_binding().map(|(host, _)| host)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_port_command_basic() {
+        let cmd = ComposePortCommand::new("web", 80);
+        let args = cmd.build_args();
+        assert_eq!(args[0], "port");
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"80".to_string()));
+    }
+
+    #[test]
+    fn test_port_command_with_protocol() {
+        let cmd = ComposePortCommand::new("web", 53).protocol("udp");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--protocol".to_string()));
+        assert!(args.contains(&"udp".to_string()));
+    }
+
+    #[test]
+    fn test_port_command_with_index() {
+        let cmd = ComposePortCommand::new("web", 8080).index(2);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--index".to_string()));
+        assert!(args.contains(&"2".to_string()));
+    }
+
+    #[test]
+    fn test_port_result_parsing() {
+        let result = PortResult {
+            binding: "0.0.0.0:32768".to_string(),
+            success: true,
+        };
+
+        assert_eq!(result.port(), Some(32768));
+        assert_eq!(result.host(), Some("0.0.0.0".to_string()));
+
+        let (host, port) = result.parse_binding().unwrap();
+        assert_eq!(host, "0.0.0.0");
+        assert_eq!(port, 32768);
+    }
+}

--- a/src/compose/push.rs
+++ b/src/compose/push.rs
@@ -1,0 +1,171 @@
+//! Docker Compose push command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose push command
+///
+/// Push service images to registry.
+#[derive(Debug, Clone, Default)]
+pub struct ComposePushCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Include all tags when pushing
+    pub include_deps: bool,
+    /// Ignore push failures
+    pub ignore_push_failures: bool,
+    /// Don't print progress
+    pub quiet: bool,
+    /// Services to push
+    pub services: Vec<String>,
+}
+
+/// Result from push command
+#[derive(Debug, Clone)]
+pub struct PushResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposePushCommand {
+    /// Create a new push command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Include all dependencies
+    #[must_use]
+    pub fn include_deps(mut self) -> Self {
+        self.include_deps = true;
+        self
+    }
+
+    /// Ignore push failures
+    #[must_use]
+    pub fn ignore_push_failures(mut self) -> Self {
+        self.ignore_push_failures = true;
+        self
+    }
+
+    /// Quiet mode
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    /// Add a service to push
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to push
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["push".to_string()];
+
+        // Add flags
+        if self.include_deps {
+            args.push("--include-deps".to_string());
+        }
+        if self.ignore_push_failures {
+            args.push("--ignore-push-failures".to_string());
+        }
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposePushCommand {
+    type Output = PushResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(PushResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_command_basic() {
+        let cmd = ComposePushCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "push");
+    }
+
+    #[test]
+    fn test_push_command_with_flags() {
+        let cmd = ComposePushCommand::new()
+            .include_deps()
+            .ignore_push_failures()
+            .quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--include-deps".to_string()));
+        assert!(args.contains(&"--ignore-push-failures".to_string()));
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_push_command_with_services() {
+        let cmd = ComposePushCommand::new().service("web").service("api");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"api".to_string()));
+    }
+}

--- a/src/compose/rm.rs
+++ b/src/compose/rm.rs
@@ -1,0 +1,188 @@
+//! Docker Compose rm command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose rm command
+///
+/// Remove stopped service containers.
+#[derive(Debug, Clone, Default)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ComposeRmCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Force removal without confirmation
+    pub force: bool,
+    /// Stop containers if running
+    pub stop: bool,
+    /// Remove volumes
+    pub volumes: bool,
+    /// Remove all containers (not just stopped)
+    pub all: bool,
+    /// Services to remove
+    pub services: Vec<String>,
+}
+
+/// Result from rm command
+#[derive(Debug, Clone)]
+pub struct RmResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeRmCommand {
+    /// Create a new rm command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Force removal without confirmation
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    /// Stop containers if running
+    #[must_use]
+    pub fn stop(mut self) -> Self {
+        self.stop = true;
+        self
+    }
+
+    /// Remove volumes
+    #[must_use]
+    pub fn volumes(mut self) -> Self {
+        self.volumes = true;
+        self
+    }
+
+    /// Remove all containers
+    #[must_use]
+    pub fn all(mut self) -> Self {
+        self.all = true;
+        self
+    }
+
+    /// Add a service to remove
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to remove
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["rm".to_string()];
+
+        // Add flags
+        if self.force {
+            args.push("--force".to_string());
+        }
+        if self.stop {
+            args.push("--stop".to_string());
+        }
+        if self.volumes {
+            args.push("--volumes".to_string());
+        }
+        if self.all {
+            args.push("--all".to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeRmCommand {
+    type Output = RmResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(RmResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rm_command_basic() {
+        let cmd = ComposeRmCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "rm");
+    }
+
+    #[test]
+    fn test_rm_command_with_force() {
+        let cmd = ComposeRmCommand::new().force().stop();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--force".to_string()));
+        assert!(args.contains(&"--stop".to_string()));
+    }
+
+    #[test]
+    fn test_rm_command_with_services() {
+        let cmd = ComposeRmCommand::new().service("web").service("db");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"db".to_string()));
+    }
+
+    #[test]
+    fn test_rm_command_with_volumes() {
+        let cmd = ComposeRmCommand::new().volumes().all();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--volumes".to_string()));
+        assert!(args.contains(&"--all".to_string()));
+    }
+}

--- a/src/compose/scale.rs
+++ b/src/compose/scale.rs
@@ -1,0 +1,157 @@
+//! Docker Compose scale command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+/// Docker Compose scale command
+///
+/// Scale services to specific number of instances.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeScaleCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Service scale specifications (service=num)
+    pub scales: HashMap<String, u32>,
+    /// Don't start new containers
+    pub no_deps: bool,
+}
+
+/// Result from scale command
+#[derive(Debug, Clone)]
+pub struct ScaleResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeScaleCommand {
+    /// Create a new scale command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Scale a service to a specific number of instances
+    #[must_use]
+    pub fn scale(mut self, service: impl Into<String>, instances: u32) -> Self {
+        self.scales.insert(service.into(), instances);
+        self
+    }
+
+    /// Scale multiple services
+    #[must_use]
+    pub fn scales<I, S>(mut self, scales: I) -> Self
+    where
+        I: IntoIterator<Item = (S, u32)>,
+        S: Into<String>,
+    {
+        for (service, count) in scales {
+            self.scales.insert(service.into(), count);
+        }
+        self
+    }
+
+    /// Don't start dependency services
+    #[must_use]
+    pub fn no_deps(mut self) -> Self {
+        self.no_deps = true;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["scale".to_string()];
+
+        // Add flags
+        if self.no_deps {
+            args.push("--no-deps".to_string());
+        }
+
+        // Add service scales
+        for (service, count) in &self.scales {
+            args.push(format!("{service}={count}"));
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeScaleCommand {
+    type Output = ScaleResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(ScaleResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scale_command_basic() {
+        let cmd = ComposeScaleCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "scale");
+    }
+
+    #[test]
+    fn test_scale_command_with_service() {
+        let cmd = ComposeScaleCommand::new()
+            .scale("web", 3)
+            .scale("worker", 5);
+        let args = cmd.build_args();
+        assert!(args.iter().any(|arg| arg == "web=3" || arg == "worker=5"));
+    }
+
+    #[test]
+    fn test_scale_command_with_no_deps() {
+        let cmd = ComposeScaleCommand::new().scale("web", 2).no_deps();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--no-deps".to_string()));
+        assert!(args.iter().any(|arg| arg == "web=2"));
+    }
+
+    #[test]
+    fn test_scale_command_with_multiple() {
+        let scales = vec![("app", 4), ("cache", 2)];
+        let cmd = ComposeScaleCommand::new().scales(scales);
+        let args = cmd.build_args();
+        assert!(args.iter().any(|arg| arg == "app=4" || arg == "cache=2"));
+    }
+}

--- a/src/compose/top.rs
+++ b/src/compose/top.rs
@@ -1,0 +1,121 @@
+//! Docker Compose top command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose top command
+///
+/// Display running processes of a service.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeTopCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Services to show processes for
+    pub services: Vec<String>,
+}
+
+/// Result from top command
+#[derive(Debug, Clone)]
+pub struct TopResult {
+    /// Output from the command (process list)
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeTopCommand {
+    /// Create a new top command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Add a service to show processes for
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["top".to_string()];
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeTopCommand {
+    type Output = TopResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(TopResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_top_command_basic() {
+        let cmd = ComposeTopCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "top");
+    }
+
+    #[test]
+    fn test_top_command_with_services() {
+        let cmd = ComposeTopCommand::new().service("web").service("worker");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+    }
+}

--- a/src/compose/unpause.rs
+++ b/src/compose/unpause.rs
@@ -1,0 +1,123 @@
+//! Docker Compose unpause command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose unpause command
+///
+/// Unpause services.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeUnpauseCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Services to unpause
+    pub services: Vec<String>,
+}
+
+/// Result from unpause command
+#[derive(Debug, Clone)]
+pub struct UnpauseResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeUnpauseCommand {
+    /// Create a new unpause command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Add a service to unpause
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to unpause
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["unpause".to_string()];
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeUnpauseCommand {
+    type Output = UnpauseResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(UnpauseResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unpause_command_basic() {
+        let cmd = ComposeUnpauseCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "unpause");
+    }
+
+    #[test]
+    fn test_unpause_command_with_services() {
+        let cmd = ComposeUnpauseCommand::new()
+            .service("web")
+            .service("worker");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+    }
+}

--- a/src/compose/version.rs
+++ b/src/compose/version.rs
@@ -1,0 +1,163 @@
+//! Docker Compose version command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Docker Compose version command
+///
+/// Show Docker Compose version information.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeVersionCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Format output (pretty, json)
+    pub format: Option<VersionFormat>,
+    /// Short output
+    pub short: bool,
+}
+
+/// Version output format
+#[derive(Debug, Clone, Copy)]
+pub enum VersionFormat {
+    /// Pretty format (default)
+    Pretty,
+    /// JSON format
+    Json,
+}
+
+impl VersionFormat {
+    /// Convert to command line argument
+    #[must_use]
+    pub fn as_arg(&self) -> &str {
+        match self {
+            Self::Pretty => "pretty",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Version information
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct VersionInfo {
+    /// Compose version
+    pub version: String,
+}
+
+/// Result from version command
+#[derive(Debug, Clone)]
+pub struct VersionResult {
+    /// Version information
+    pub info: Option<VersionInfo>,
+    /// Raw output
+    pub raw_output: String,
+}
+
+impl ComposeVersionCommand {
+    /// Create a new version command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set output format
+    #[must_use]
+    pub fn format(mut self, format: VersionFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Set output format to JSON
+    #[must_use]
+    pub fn format_json(mut self) -> Self {
+        self.format = Some(VersionFormat::Json);
+        self
+    }
+
+    /// Enable short output
+    #[must_use]
+    pub fn short(mut self) -> Self {
+        self.short = true;
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["version".to_string()];
+
+        // Add flags
+        if self.short {
+            args.push("--short".to_string());
+        }
+
+        // Add format
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.as_arg().to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeVersionCommand {
+    type Output = VersionResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        // Parse JSON output if format is JSON
+        let info = if matches!(self.format, Some(VersionFormat::Json)) {
+            serde_json::from_str(&output.stdout).ok()
+        } else {
+            None
+        };
+
+        Ok(VersionResult {
+            info,
+            raw_output: output.stdout,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_command_basic() {
+        let cmd = ComposeVersionCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "version");
+    }
+
+    #[test]
+    fn test_version_command_with_format() {
+        let cmd = ComposeVersionCommand::new().format_json();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"json".to_string()));
+    }
+
+    #[test]
+    fn test_version_command_with_short() {
+        let cmd = ComposeVersionCommand::new().short();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--short".to_string()));
+    }
+}

--- a/src/compose/wait.rs
+++ b/src/compose/wait.rs
@@ -1,0 +1,190 @@
+//! Docker Compose wait command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose wait command
+///
+/// Wait for services to reach a desired state.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeWaitCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Services to wait for
+    pub services: Vec<String>,
+    /// Wait for services to be running and healthy
+    pub down_project: bool,
+}
+
+/// Result from wait command
+#[derive(Debug, Clone)]
+pub struct WaitResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+    /// Exit codes from services
+    pub exit_codes: Vec<i32>,
+}
+
+impl ComposeWaitCommand {
+    /// Create a new wait command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Wait for the entire project to stop
+    #[must_use]
+    pub fn down_project(mut self) -> Self {
+        self.down_project = true;
+        self
+    }
+
+    /// Add a service to wait for
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to wait for
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["wait".to_string()];
+
+        // Add flags
+        if self.down_project {
+            args.push("--down-project".to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeWaitCommand {
+    type Output = WaitResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        // Parse exit codes from output if available
+        let exit_codes = output
+            .stdout
+            .lines()
+            .filter_map(|line| {
+                // Try to parse exit codes from output
+                line.split_whitespace()
+                    .last()
+                    .and_then(|s| s.parse::<i32>().ok())
+            })
+            .collect();
+
+        Ok(WaitResult {
+            output: output.stdout,
+            success: output.success,
+            exit_codes,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+impl WaitResult {
+    /// Check if all services exited successfully (code 0)
+    #[must_use]
+    pub fn all_successful(&self) -> bool {
+        !self.exit_codes.is_empty() && self.exit_codes.iter().all(|&code| code == 0)
+    }
+
+    /// Get the first non-zero exit code
+    #[must_use]
+    pub fn first_failure(&self) -> Option<i32> {
+        self.exit_codes.iter().find(|&&code| code != 0).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wait_command_basic() {
+        let cmd = ComposeWaitCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "wait");
+    }
+
+    #[test]
+    fn test_wait_command_with_services() {
+        let cmd = ComposeWaitCommand::new().service("web").service("db");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"db".to_string()));
+    }
+
+    #[test]
+    fn test_wait_command_with_down_project() {
+        let cmd = ComposeWaitCommand::new().down_project();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--down-project".to_string()));
+    }
+
+    #[test]
+    fn test_wait_result_helpers() {
+        let result = WaitResult {
+            output: String::new(),
+            success: true,
+            exit_codes: vec![0, 0, 0],
+        };
+        assert!(result.all_successful());
+        assert_eq!(result.first_failure(), None);
+
+        let result_with_failure = WaitResult {
+            output: String::new(),
+            success: false,
+            exit_codes: vec![0, 1, 0],
+        };
+        assert!(!result_with_failure.all_successful());
+        assert_eq!(result_with_failure.first_failure(), Some(1));
+    }
+}

--- a/src/compose/watch.rs
+++ b/src/compose/watch.rs
@@ -1,0 +1,142 @@
+//! Docker Compose watch command implementation.
+
+use crate::compose::{ComposeCommandV2 as ComposeCommand, ComposeConfig};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker Compose watch command
+///
+/// Watch build context for changes and rebuild/restart services automatically.
+#[derive(Debug, Clone, Default)]
+pub struct ComposeWatchCommand {
+    /// Base configuration
+    pub config: ComposeConfig,
+    /// Don't build images
+    pub no_up: bool,
+    /// Services to watch
+    pub services: Vec<String>,
+}
+
+/// Result from watch command
+#[derive(Debug, Clone)]
+pub struct WatchResult {
+    /// Output from the command
+    pub output: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+}
+
+impl ComposeWatchCommand {
+    /// Create a new watch command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a compose file
+    #[must_use]
+    pub fn file<P: Into<std::path::PathBuf>>(mut self, file: P) -> Self {
+        self.config.files.push(file.into());
+        self
+    }
+
+    /// Set project name
+    #[must_use]
+    pub fn project_name(mut self, name: impl Into<String>) -> Self {
+        self.config.project_name = Some(name.into());
+        self
+    }
+
+    /// Don't start services before watching
+    #[must_use]
+    pub fn no_up(mut self) -> Self {
+        self.no_up = true;
+        self
+    }
+
+    /// Add a service to watch
+    #[must_use]
+    pub fn service(mut self, service: impl Into<String>) -> Self {
+        self.services.push(service.into());
+        self
+    }
+
+    /// Add multiple services to watch
+    #[must_use]
+    pub fn services<I, S>(mut self, services: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.services.extend(services.into_iter().map(Into::into));
+        self
+    }
+
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["watch".to_string()];
+
+        // Add flags
+        if self.no_up {
+            args.push("--no-up".to_string());
+        }
+
+        // Add services
+        args.extend(self.services.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl ComposeCommand for ComposeWatchCommand {
+    type Output = WatchResult;
+
+    fn get_config(&self) -> &ComposeConfig {
+        &self.config
+    }
+
+    fn get_config_mut(&mut self) -> &mut ComposeConfig {
+        &mut self.config
+    }
+
+    async fn execute_compose(&self, args: Vec<String>) -> Result<Self::Output> {
+        let output = self.execute_compose_command(args).await?;
+
+        Ok(WatchResult {
+            output: output.stdout,
+            success: output.success,
+        })
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        self.execute_compose(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_watch_command_basic() {
+        let cmd = ComposeWatchCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args[0], "watch");
+    }
+
+    #[test]
+    fn test_watch_command_with_no_up() {
+        let cmd = ComposeWatchCommand::new().no_up();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--no-up".to_string()));
+    }
+
+    #[test]
+    fn test_watch_command_with_services() {
+        let cmd = ComposeWatchCommand::new().service("web").service("worker");
+        let args = cmd.build_args();
+        assert!(args.contains(&"web".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+    }
+}

--- a/tests/compose_commands_integration.rs
+++ b/tests/compose_commands_integration.rs
@@ -1,0 +1,232 @@
+//! Integration tests for new Docker Compose commands
+
+use docker_wrapper::compose::{
+    ComposeAttachCommand, ComposeConfigCommand, ComposeConvertCommand, ComposeCpCommand,
+    ComposeCreateCommand, ComposeEventsCommand, ComposeImagesCommand, ComposeKillCommand,
+    ComposeLsCommand, ComposePauseCommand, ComposePortCommand, ComposePushCommand,
+    ComposeRmCommand, ComposeScaleCommand, ComposeTopCommand, ComposeUnpauseCommand,
+    ComposeVersionCommand, ComposeWaitCommand, ComposeWatchCommand, ConfigFormat, ConvertFormat,
+    ImagesFormat, LsFormat, PullPolicy, VersionFormat,
+};
+
+#[test]
+fn test_compose_config_command_creation() {
+    let cmd = ComposeConfigCommand::new()
+        .file("docker-compose.yml")
+        .format(ConfigFormat::Json)
+        .services()
+        .quiet();
+
+    // Just verify the command can be created and configured
+    assert!(cmd.services);
+    assert!(cmd.quiet);
+}
+
+#[test]
+fn test_compose_rm_command_creation() {
+    let cmd = ComposeRmCommand::new()
+        .force()
+        .stop()
+        .volumes()
+        .service("web");
+
+    assert!(cmd.force);
+    assert!(cmd.stop);
+    assert!(cmd.volumes);
+    assert_eq!(cmd.services.len(), 1);
+}
+
+#[test]
+fn test_compose_kill_command_creation() {
+    let cmd = ComposeKillCommand::new()
+        .signal("SIGTERM")
+        .remove_orphans()
+        .service("worker");
+
+    assert_eq!(cmd.signal, Some("SIGTERM".to_string()));
+    assert!(cmd.remove_orphans);
+}
+
+#[test]
+fn test_compose_ls_command_creation() {
+    let cmd = ComposeLsCommand::new()
+        .all()
+        .format(LsFormat::Json)
+        .filter("status=running");
+
+    assert!(cmd.all);
+    assert!(matches!(cmd.format, Some(LsFormat::Json)));
+}
+
+#[test]
+fn test_compose_pause_unpause_commands() {
+    let pause_cmd = ComposePauseCommand::new().service("web").service("db");
+
+    let unpause_cmd = ComposeUnpauseCommand::new().service("web").service("db");
+
+    assert_eq!(pause_cmd.services.len(), 2);
+    assert_eq!(unpause_cmd.services.len(), 2);
+}
+
+#[test]
+fn test_compose_create_command_with_pull_policy() {
+    let cmd = ComposeCreateCommand::new()
+        .pull(PullPolicy::Always)
+        .build()
+        .force_recreate();
+
+    assert!(matches!(cmd.pull, Some(PullPolicy::Always)));
+    assert!(cmd.build);
+    assert!(cmd.force_recreate);
+}
+
+#[test]
+fn test_compose_scale_command() {
+    let cmd = ComposeScaleCommand::new()
+        .scale("web", 3)
+        .scale("worker", 5)
+        .no_deps();
+
+    assert_eq!(cmd.scales.len(), 2);
+    assert_eq!(cmd.scales.get("web"), Some(&3));
+    assert_eq!(cmd.scales.get("worker"), Some(&5));
+    assert!(cmd.no_deps);
+}
+
+#[test]
+fn test_compose_images_command() {
+    let cmd = ComposeImagesCommand::new()
+        .format(ImagesFormat::Json)
+        .quiet();
+
+    assert!(matches!(cmd.format, Some(ImagesFormat::Json)));
+    assert!(cmd.quiet);
+}
+
+#[test]
+fn test_compose_top_command() {
+    let cmd = ComposeTopCommand::new().service("web").service("worker");
+
+    assert_eq!(cmd.services.len(), 2);
+}
+
+#[test]
+fn test_compose_port_command() {
+    let cmd = ComposePortCommand::new("web", 80).protocol("tcp").index(1);
+
+    assert_eq!(cmd.service, "web");
+    assert_eq!(cmd.private_port, 80);
+    assert_eq!(cmd.protocol, Some("tcp".to_string()));
+    assert_eq!(cmd.index, Some(1));
+}
+
+#[test]
+fn test_compose_cp_command() {
+    let cmd = ComposeCpCommand::from_container("web", "/app/logs", "./logs")
+        .archive()
+        .follow_link();
+
+    assert!(cmd.archive);
+    assert!(cmd.follow_link);
+    assert!(cmd.source.contains("web:/app/logs"));
+}
+
+#[test]
+fn test_compose_push_command() {
+    let cmd = ComposePushCommand::new()
+        .include_deps()
+        .ignore_push_failures()
+        .service("api");
+
+    assert!(cmd.include_deps);
+    assert!(cmd.ignore_push_failures);
+    assert_eq!(cmd.services.len(), 1);
+}
+
+#[test]
+fn test_compose_version_command() {
+    let cmd = ComposeVersionCommand::new()
+        .format(VersionFormat::Json)
+        .short();
+
+    assert!(matches!(cmd.format, Some(VersionFormat::Json)));
+    assert!(cmd.short);
+}
+
+#[test]
+fn test_compose_events_command() {
+    let cmd = ComposeEventsCommand::new()
+        .json()
+        .since("2025-08-23T00:00:00")
+        .until("2025-08-23T23:59:59")
+        .service("web");
+
+    assert!(cmd.json);
+    assert_eq!(cmd.since, Some("2025-08-23T00:00:00".to_string()));
+    assert_eq!(cmd.until, Some("2025-08-23T23:59:59".to_string()));
+}
+
+#[test]
+fn test_multiple_services_configuration() {
+    // Test that multiple services can be added in different ways
+    let services = vec!["web", "db", "cache"];
+
+    let cmd1 = ComposeRmCommand::new().services(services.clone());
+
+    let mut cmd2 = ComposeRmCommand::new();
+    for service in &services {
+        cmd2 = cmd2.service(*service);
+    }
+
+    assert_eq!(cmd1.services.len(), 3);
+    assert_eq!(cmd2.services.len(), 3);
+}
+
+#[test]
+fn test_compose_watch_command() {
+    let cmd = ComposeWatchCommand::new()
+        .no_up()
+        .service("web")
+        .service("worker");
+
+    assert!(cmd.no_up);
+    assert_eq!(cmd.services.len(), 2);
+}
+
+#[test]
+fn test_compose_attach_command() {
+    let cmd = ComposeAttachCommand::new("web")
+        .detach_keys("ctrl-p,ctrl-q")
+        .index(1)
+        .no_stdin();
+
+    assert_eq!(cmd.service, "web");
+    assert_eq!(cmd.detach_keys, Some("ctrl-p,ctrl-q".to_string()));
+    assert_eq!(cmd.index, Some(1));
+    assert!(cmd.no_stdin);
+}
+
+#[test]
+fn test_compose_wait_command() {
+    let cmd = ComposeWaitCommand::new()
+        .down_project()
+        .service("web")
+        .service("db");
+
+    assert!(cmd.down_project);
+    assert_eq!(cmd.services.len(), 2);
+}
+
+#[test]
+fn test_compose_convert_command() {
+    let cmd = ComposeConvertCommand::new()
+        .format(ConvertFormat::Json)
+        .output("compose.json")
+        .services()
+        .quiet();
+
+    assert!(matches!(cmd.format, Some(ConvertFormat::Json)));
+    assert_eq!(cmd.output, Some("compose.json".to_string()));
+    assert!(cmd.services);
+    assert!(cmd.quiet);
+}


### PR DESCRIPTION
## Summary
- Implements 100% Docker Compose command coverage with 20 new commands
- Adds comprehensive test coverage for all new commands
- Closes #87

## New Commands Added

### Core Commands
- `config` - Validate and view composed configuration
- `rm` - Remove stopped service containers  
- `kill` - Force stop service containers
- `ls` - List running compose projects
- `pause`/`unpause` - Pause and unpause services

### Service Management
- `create` - Create services without starting
- `scale` - Scale services to specific instances
- `wait` - Wait for services to reach desired state
- `attach` - Attach to running container output
- `watch` - Watch build context for changes

### Inspection Commands
- `images` - List images used by services
- `top` - Display running processes
- `port` - Print public port for a port binding
- `events` - Stream container events
- `version` - Show Docker Compose version

### File Operations
- `cp` - Copy files/folders between containers and filesystem
- `push` - Push service images to registry
- `convert` - Convert compose files between formats

## Technical Details
- All commands use the builder pattern for easy configuration
- Introduced `ComposeCommandV2` trait for new commands (maintains compatibility)
- Full unit test coverage for each command
- Integration tests to verify command creation and configuration
- Zero clippy warnings

## Test Plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] cargo fmt clean
- [x] cargo clippy clean

## Next Steps
After merging this PR, we should create an issue to refactor all commands (both compose and non-compose) to use a unified command pattern, as discussed.