### PR TITLE
fix: Add missing toolchain parameter to rust-toolchain actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -103,6 +105,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -134,6 +138,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -201,6 +207,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -223,6 +231,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies and tools
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -61,6 +63,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
         with:
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
@@ -50,6 +51,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@v2
@@ -104,6 +106,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
## Summary
Fixes CI failures caused by missing toolchain parameter in rust-toolchain actions.

## Problem
After pinning dtolnay/rust-toolchain to a specific commit (to resolve other issues), many workflow jobs started failing with:
```
error: invalid toolchain name ''
```

The pinned version requires an explicit `toolchain` parameter, but many of our workflow steps were missing it.

## Solution
Added `toolchain: stable` to all rust-toolchain action uses that were missing the parameter:
- CI workflow: Docker integration tests, code coverage, security audit, and other jobs
- Dependencies workflow: Both check-deps and update-check jobs
- Release-Please workflow: Publish and docs jobs
- Quick-Check workflow: Fast build check job

## Test Plan
- [x] All workflow files updated
- [ ] CI should pass after this fix

This should resolve all the "invalid toolchain name" errors we've been seeing in CI.