### PR TITLE
feat: migrate system/info commands to DockerCommandV2

### DIFF
--- a/examples/basic_docker_patterns.rs
+++ b/examples/basic_docker_patterns.rs
@@ -3,7 +3,7 @@
 //! This example shows the most common Docker usage patterns that developers
 //! use daily, with simple and clear demonstrations.
 
-use docker_wrapper::{DockerCommand, VersionCommand};
+use docker_wrapper::{DockerCommandV2, VersionCommand};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/ps_integration.rs
+++ b/tests/ps_integration.rs
@@ -3,9 +3,8 @@
 //! These tests validate the docker ps command implementation
 //! with real Docker commands and containers.
 
-use docker_wrapper::command::DockerCommandV2;
 use docker_wrapper::prerequisites::ensure_docker;
-use docker_wrapper::{DockerCommand, PsCommand, RunCommand};
+use docker_wrapper::{DockerCommandV2, PsCommand, RunCommand};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -330,7 +329,7 @@ async fn test_ps_command_builder() {
         .size()
         .quiet();
 
-    let args = complex_ps.build_args();
+    let args = complex_ps.build_command_args();
 
     // Verify critical components are present (build_args doesn't include "ps" command itself)
     assert!(args.contains(&"--all".to_string()));


### PR DESCRIPTION
## Summary
- Migrated 5 system/info commands to the new DockerCommandV2 trait pattern
- Continues the systematic migration from DockerCommand to DockerCommandV2

## Commands Migrated
- `version`: Docker version information  
- `info`: Docker system information
- `inspect`: Inspect Docker objects
- `ps`: List containers
- `top`: Display running processes

## Changes
- Made executor field public for extensibility
- Added get_executor() and get_executor_mut() methods
- Updated build_command_args() to include command name as first argument
- Added raw args support via executor.raw_args
- Updated execute() method to use new pattern
- Removed legacy DockerCommand trait implementations
- Fixed all related integration tests

## Test Results
- All 682 tests passing
- Zero clippy warnings
- Formatted with cargo fmt

Related to #100