### PR TITLE
feat: migrate image/container manipulation commands to DockerCommandV2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,9 +76,9 @@ When migrating commands from `DockerCommand` to `DockerCommandV2`:
 
 ### Migration Status
 
-**Completed (46 commands)**: attach, build, create, exec, login, logout, logs, pull, push, restart, run, search, start, stats, stop, tag, images, all compose_* commands
+**Completed (52 commands)**: attach, build, commit, cp, create, diff, exec, export, kill, login, logout, logs, port, pull, push, restart, run, search, start, stats, stop, tag, images, all compose_* commands
 
-**Remaining (28 commands)**: bake, commit, cp, diff, events, export, history, import, info, inspect, kill, load, network, pause, port, ps, rename, rm, rmi, save, system, top, unpause, update, version, volume, wait, container_prune, image_prune
+**Remaining (22 commands)**: bake, events, history, import, info, inspect, load, network, pause, ps, rename, rm, rmi, save, system, top, unpause, update, version, volume, wait, container_prune, image_prune
 
 ## Key Implementation Rules
 

--- a/tests/info_integration.rs
+++ b/tests/info_integration.rs
@@ -3,7 +3,7 @@
 //! These tests validate the info command functionality against a real Docker daemon.
 //! They test the command construction, execution, and output parsing.
 
-use docker_wrapper::{ensure_docker, DockerCommandV2, InfoCommand};
+use docker_wrapper::{ensure_docker, InfoCommand};
 
 /// Helper to check if Docker is available for testing
 async fn setup_docker() -> Result<(), Box<dyn std::error::Error>> {
@@ -195,13 +195,13 @@ async fn test_info_empty_format_handling() -> Result<(), Box<dyn std::error::Err
 
     // Test with empty format (should behave like default)
     let command = InfoCommand::new().format("");
-    let _args = command.build_command_args();
+    let args = command.build_command_args();
 
     // Should still produce valid command
     let args = command.build_command_args();
     assert_eq!(args[0], "info");
     // Empty format still gets passed as a flag
-    assert_eq!(_args, vec!["info", "--format", ""]);
+    assert_eq!(args, vec!["info", "--format", ""]);
     Ok(())
 }
 

--- a/tests/version_integration.rs
+++ b/tests/version_integration.rs
@@ -3,7 +3,7 @@
 //! These tests validate the version command functionality against a real Docker daemon.
 //! They test the command construction, execution, and output parsing.
 
-use docker_wrapper::{ensure_docker, DockerCommandV2, VersionCommand};
+use docker_wrapper::{ensure_docker, VersionCommand};
 
 /// Helper to check if Docker is available for testing
 async fn setup_docker() -> Result<(), Box<dyn std::error::Error>> {
@@ -111,6 +111,7 @@ async fn test_version_command_name() -> Result<(), Box<dyn std::error::Error>> {
     setup_docker().await?;
 
     let command = VersionCommand::new();
+    let args = command.build_command_args();
     assert_eq!(args[0], "version");
     Ok(())
 }
@@ -221,11 +222,11 @@ async fn test_version_validation() -> Result<(), Box<dyn std::error::Error>> {
     // Test command validation
     let command = VersionCommand::new().format("json");
 
-    // Test command name
-    assert_eq!(args[0], "version");
-
     // Test build args format
     let args = command.build_command_args();
+
+    // Test command name
+    assert_eq!(args[0], "version");
     assert!(!args.is_empty());
     assert!(args.contains(&"--format".to_string()));
     assert!(args.contains(&"json".to_string()));


### PR DESCRIPTION
## Summary
- Migrated 6 image/container manipulation commands to the new DockerCommandV2 trait pattern
- Continues the systematic migration from DockerCommand to DockerCommandV2

## Commands Migrated
- `kill`: Send signals to containers
- `port`: List port mappings
- `diff`: Show filesystem changes
- `commit`: Create new image from container
- `cp`: Copy files between container and host
- `export`: Export container filesystem

## Changes
- Made executor field public for extensibility
- Added get_executor() and get_executor_mut() methods to trait implementation
- Updated build_command_args() to include command name as first argument
- Added raw args support via executor.raw_args
- Updated execute() method to use new pattern
- Removed legacy DockerCommand trait implementations
- Updated all unit tests to use build_command_args()

## Test Results
- All 679 tests passing
- Zero clippy warnings (lib and bins)
- Formatted with cargo fmt

Related to #100