### PR TITLE
fix: remove environment requirement from publish workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: needs.release-please.outputs.release_created
-    environment: release
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

This PR fixes the release workflow that has been preventing crates.io publication since v0.2.0.

## Problem

Releases v0.2.1 and v0.2.2 were successfully created on GitHub but never published to crates.io. Investigation revealed that the workflow was failing because it referenced a non-existent 'release' environment.

## Solution

- Remove `environment: release` requirement from the publish-crates job
- The CARGO_REGISTRY_TOKEN secret already provides sufficient protection

## Impact

- Future releases will automatically publish to crates.io when the release PR is merged
- This fixes the issue where v0.2.1 and v0.2.2 never made it to crates.io
- The pending v0.3.0 release (#83) will publish correctly once this is merged

## Testing

This is a minimal change that only removes the environment requirement. No code changes, keeping edition 2021 to maintain MSRV compatibility.