### PR TITLE
fix: correct release-plz action path

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       
       - name: Run release-plz
-        uses: release-plz/release-plz-action@v0.5.112
+        uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Fixes the release-plz workflow to use the correct action path.

The action is located at `release-plz/action`, not `release-plz/release-plz-action`.

This was causing the workflow to fail with:
> Unable to resolve action release-plz/release-plz-action, repository not found