### PR TITLE
fix: remove invalid pr_body_template from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,24 +32,3 @@ git_tag_name = "v{{ version }}"
 
 # Changelog handled by git-cliff in separate workflow
 changelog_update = false
-
-# PR body template
-pr_body_template = """
-## Release {{ version }}
-
-This PR was automatically created by release-plz.
-
-### Changes
-
-See commit history for detailed changes.
-
-### Checklist
-- [ ] CI passes
-- [ ] Version bump looks correct
-- [ ] Changelog entries are accurate
-
-Once merged, this will:
-- Create a GitHub release with tag v{{ version }}
-- Publish to crates.io
-- Update CHANGELOG.md with git-cliff
-"""


### PR DESCRIPTION
Removes the `pr_body_template` field from the `[[package]]` section of release-plz.toml.

This field is not valid in the package section and causes the release-plz workflow to fail with:

> invalid config file (/home/runner/work/docker-wrapper/docker-wrapper/release-plz.toml): TOML parse error: unknown field `pr_body_template`

This fix allows the release-plz workflow to run successfully.