### PR TITLE
feat: add docker context management commands

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -37,6 +37,7 @@ pub mod compose_stop;
 pub mod compose_unpause;
 pub mod compose_up;
 pub mod container_prune;
+pub mod context;
 pub mod cp;
 pub mod create;
 pub mod diff;

--- a/src/command/context/create.rs
+++ b/src/command/context/create.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextCreateCommand;
+/// use docker_wrapper::{ContextCreateCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Create a context for a remote Docker daemon

--- a/src/command/context/create.rs
+++ b/src/command/context/create.rs
@@ -1,0 +1,244 @@
+//! Docker context create command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker context create command builder
+///
+/// Create a new Docker context.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextCreateCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Create a context for a remote Docker daemon
+/// ContextCreateCommand::new("production")
+///     .description("Production environment")
+///     .docker_host("ssh://user@remote-host")
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextCreateCommand {
+    /// Context name
+    name: String,
+    /// Context description
+    description: Option<String>,
+    /// Docker host
+    docker_host: Option<String>,
+    /// Default stack orchestrator
+    default_stack_orchestrator: Option<String>,
+    /// Docker API endpoint
+    docker_api_endpoint: Option<String>,
+    /// Kubernetes config file
+    kubernetes_config_file: Option<String>,
+    /// Kubernetes context
+    kubernetes_context: Option<String>,
+    /// Kubernetes namespace
+    kubernetes_namespace: Option<String>,
+    /// Kubernetes API endpoint
+    kubernetes_api_endpoint: Option<String>,
+    /// Create context from existing context
+    from: Option<String>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextCreateCommand {
+    /// Create a new context create command
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            docker_host: None,
+            default_stack_orchestrator: None,
+            docker_api_endpoint: None,
+            kubernetes_config_file: None,
+            kubernetes_context: None,
+            kubernetes_namespace: None,
+            kubernetes_api_endpoint: None,
+            from: None,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Set context description
+    #[must_use]
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Set Docker host
+    #[must_use]
+    pub fn docker_host(mut self, host: impl Into<String>) -> Self {
+        self.docker_host = Some(host.into());
+        self
+    }
+
+    /// Set default stack orchestrator (swarm|kubernetes|all)
+    #[must_use]
+    pub fn default_stack_orchestrator(mut self, orchestrator: impl Into<String>) -> Self {
+        self.default_stack_orchestrator = Some(orchestrator.into());
+        self
+    }
+
+    /// Set Docker API endpoint
+    #[must_use]
+    pub fn docker_api_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.docker_api_endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Set Kubernetes config file
+    #[must_use]
+    pub fn kubernetes_config_file(mut self, file: impl Into<String>) -> Self {
+        self.kubernetes_config_file = Some(file.into());
+        self
+    }
+
+    /// Set Kubernetes context
+    #[must_use]
+    pub fn kubernetes_context(mut self, context: impl Into<String>) -> Self {
+        self.kubernetes_context = Some(context.into());
+        self
+    }
+
+    /// Set Kubernetes namespace
+    #[must_use]
+    pub fn kubernetes_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.kubernetes_namespace = Some(namespace.into());
+        self
+    }
+
+    /// Set Kubernetes API endpoint
+    #[must_use]
+    pub fn kubernetes_api_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.kubernetes_api_endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Create context from existing context
+    #[must_use]
+    pub fn from(mut self, context: impl Into<String>) -> Self {
+        self.from = Some(context.into());
+        self
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextCreateCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "create".to_string()];
+
+        if let Some(desc) = &self.description {
+            args.push("--description".to_string());
+            args.push(desc.clone());
+        }
+
+        if let Some(host) = &self.docker_host {
+            args.push("--docker".to_string());
+            args.push(format!("host={host}"));
+        }
+
+        if let Some(orchestrator) = &self.default_stack_orchestrator {
+            args.push("--default-stack-orchestrator".to_string());
+            args.push(orchestrator.clone());
+        }
+
+        if let Some(endpoint) = &self.docker_api_endpoint {
+            args.push("--docker".to_string());
+            args.push(format!("api-endpoint={endpoint}"));
+        }
+
+        if let Some(file) = &self.kubernetes_config_file {
+            args.push("--kubernetes".to_string());
+            args.push(format!("config-file={file}"));
+        }
+
+        if let Some(context) = &self.kubernetes_context {
+            args.push("--kubernetes".to_string());
+            args.push(format!("context={context}"));
+        }
+
+        if let Some(namespace) = &self.kubernetes_namespace {
+            args.push("--kubernetes".to_string());
+            args.push(format!("namespace={namespace}"));
+        }
+
+        if let Some(endpoint) = &self.kubernetes_api_endpoint {
+            args.push("--kubernetes".to_string());
+            args.push(format!("api-endpoint={endpoint}"));
+        }
+
+        if let Some(from) = &self.from {
+            args.push("--from".to_string());
+            args.push(from.clone());
+        }
+
+        args.push(self.name.clone());
+
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_create_basic() {
+        let cmd = ContextCreateCommand::new("test-context");
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "create");
+        assert!(args.contains(&"test-context".to_string()));
+    }
+
+    #[test]
+    fn test_context_create_with_description() {
+        let cmd =
+            ContextCreateCommand::new("test-context").description("Test context for development");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--description".to_string()));
+        assert!(args.contains(&"Test context for development".to_string()));
+    }
+
+    #[test]
+    fn test_context_create_with_docker_host() {
+        let cmd = ContextCreateCommand::new("remote").docker_host("ssh://user@remote-host");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--docker".to_string()));
+        assert!(args.contains(&"host=ssh://user@remote-host".to_string()));
+    }
+
+    #[test]
+    fn test_context_create_from_existing() {
+        let cmd = ContextCreateCommand::new("new-context").from("default");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--from".to_string()));
+        assert!(args.contains(&"default".to_string()));
+    }
+}

--- a/src/command/context/inspect.rs
+++ b/src/command/context/inspect.rs
@@ -1,0 +1,139 @@
+//! Docker context inspect command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Docker context inspect command builder
+///
+/// Display detailed information on one or more contexts.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextInspectCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Inspect a context
+/// let info = ContextInspectCommand::new("production")
+///     .format("{{.Endpoints.docker.Host}}")
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextInspectCommand {
+    /// Contexts to inspect
+    contexts: Vec<String>,
+    /// Format the output
+    format: Option<String>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextInspectCommand {
+    /// Create a new context inspect command
+    #[must_use]
+    pub fn new(context: impl Into<String>) -> Self {
+        Self {
+            contexts: vec![context.into()],
+            format: None,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Add another context to inspect
+    #[must_use]
+    pub fn add_context(mut self, context: impl Into<String>) -> Self {
+        self.contexts.push(context.into());
+        self
+    }
+
+    /// Format the output using a Go template
+    #[must_use]
+    pub fn format(mut self, template: impl Into<String>) -> Self {
+        self.format = Some(template.into());
+        self
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextInspectCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "inspect".to_string()];
+
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.clone());
+        }
+
+        args.extend(self.contexts.clone());
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+/// Extension methods for `ContextInspectCommand` output
+impl CommandOutput {
+    /// Parse context information as JSON
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON parsing fails
+    pub fn parse_context_info(&self) -> Result<Vec<Value>> {
+        if self.stdout.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Docker returns array of contexts
+        let contexts: Vec<Value> = serde_json::from_str(&self.stdout)?;
+        Ok(contexts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_inspect_single() {
+        let cmd = ContextInspectCommand::new("production");
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "inspect");
+        assert!(args.contains(&"production".to_string()));
+    }
+
+    #[test]
+    fn test_context_inspect_multiple() {
+        let cmd = ContextInspectCommand::new("context1").add_context("context2");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"context1".to_string()));
+        assert!(args.contains(&"context2".to_string()));
+    }
+
+    #[test]
+    fn test_context_inspect_with_format() {
+        let cmd = ContextInspectCommand::new("production").format("{{.Name}}");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"{{.Name}}".to_string()));
+    }
+}

--- a/src/command/context/inspect.rs
+++ b/src/command/context/inspect.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextInspectCommand;
+/// use docker_wrapper::{ContextInspectCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Inspect a context

--- a/src/command/context/ls.rs
+++ b/src/command/context/ls.rs
@@ -1,0 +1,206 @@
+//! Docker context ls command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+/// Information about a Docker context
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ContextInfo {
+    /// Context name
+    pub name: String,
+
+    /// Description of the context
+    #[serde(default)]
+    pub description: String,
+
+    /// Docker endpoint
+    #[serde(rename = "DockerEndpoint")]
+    pub docker_endpoint: String,
+
+    /// Kubernetes endpoint (if configured)
+    #[serde(rename = "KubernetesEndpoint", default)]
+    pub kubernetes_endpoint: String,
+
+    /// Whether this is the current context
+    #[serde(default)]
+    pub current: bool,
+}
+
+/// Docker context ls command builder
+///
+/// Lists all Docker contexts.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextLsCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let contexts = ContextLsCommand::new()
+///     .quiet()
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextLsCommand {
+    /// Format the output
+    format: Option<String>,
+    /// Only display context names
+    quiet: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextLsCommand {
+    /// Create a new context ls command
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            format: None,
+            quiet: false,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Format the output using a Go template
+    #[must_use]
+    pub fn format(mut self, template: impl Into<String>) -> Self {
+        self.format = Some(template.into());
+        self
+    }
+
+    /// Format output as JSON
+    #[must_use]
+    pub fn format_json(self) -> Self {
+        self.format("json")
+    }
+
+    /// Only display context names
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+}
+
+impl Default for ContextLsCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextLsCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "ls".to_string()];
+
+        if let Some(format) = &self.format {
+            args.push("--format".to_string());
+            args.push(format.clone());
+        }
+
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+/// Extension methods for `ContextLsCommand` output
+impl CommandOutput {
+    /// Parse contexts from JSON output
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON parsing fails
+    pub fn parse_contexts(&self) -> Result<Vec<ContextInfo>> {
+        if self.stdout.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let contexts: Vec<ContextInfo> = serde_json::from_str(&self.stdout)?;
+        Ok(contexts)
+    }
+
+    /// Get the current context name
+    #[must_use]
+    pub fn current_context(&self) -> Option<String> {
+        // Look for the line with an asterisk indicating current context
+        for line in self.stdout.lines() {
+            if line.contains('*') {
+                // Extract context name (usually second column after asterisk)
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if let Some(name) = parts.first() {
+                    if name == &"*" {
+                        if let Some(actual_name) = parts.get(1) {
+                            return Some((*actual_name).to_string());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_ls_basic() {
+        let cmd = ContextLsCommand::new();
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "ls");
+    }
+
+    #[test]
+    fn test_context_ls_with_format() {
+        let cmd = ContextLsCommand::new().format("{{.Name}}");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--format".to_string()));
+        assert!(args.contains(&"{{.Name}}".to_string()));
+    }
+
+    #[test]
+    fn test_context_ls_quiet() {
+        let cmd = ContextLsCommand::new().quiet();
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_current_context_parsing() {
+        let output = CommandOutput {
+            stdout: "default          Default local daemon                          \n* production *   Production environment  unix:///var/run/docker.sock".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+
+        assert_eq!(output.current_context(), Some("production".to_string()));
+    }
+}

--- a/src/command/context/ls.rs
+++ b/src/command/context/ls.rs
@@ -36,7 +36,7 @@ pub struct ContextInfo {
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextLsCommand;
+/// use docker_wrapper::{ContextLsCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let contexts = ContextLsCommand::new()

--- a/src/command/context/mod.rs
+++ b/src/command/context/mod.rs
@@ -1,0 +1,18 @@
+//! Docker context management commands
+//!
+//! This module provides commands for managing Docker contexts, which allow
+//! you to quickly switch between different Docker daemons.
+
+pub mod create;
+pub mod inspect;
+pub mod ls;
+pub mod rm;
+pub mod update;
+pub mod use_context;
+
+pub use create::ContextCreateCommand;
+pub use inspect::ContextInspectCommand;
+pub use ls::ContextLsCommand;
+pub use rm::ContextRmCommand;
+pub use update::ContextUpdateCommand;
+pub use use_context::ContextUseCommand;

--- a/src/command/context/mod.rs
+++ b/src/command/context/mod.rs
@@ -12,7 +12,7 @@ pub mod use_context;
 
 pub use create::ContextCreateCommand;
 pub use inspect::ContextInspectCommand;
-pub use ls::ContextLsCommand;
+pub use ls::{ContextInfo, ContextLsCommand};
 pub use rm::ContextRmCommand;
 pub use update::ContextUpdateCommand;
 pub use use_context::ContextUseCommand;

--- a/src/command/context/rm.rs
+++ b/src/command/context/rm.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextRmCommand;
+/// use docker_wrapper::{ContextRmCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Remove a context

--- a/src/command/context/rm.rs
+++ b/src/command/context/rm.rs
@@ -1,0 +1,151 @@
+//! Docker context rm command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker context rm command builder
+///
+/// Remove one or more Docker contexts.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextRmCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Remove a context
+/// ContextRmCommand::new("old-context")
+///     .force()
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextRmCommand {
+    /// Contexts to remove
+    contexts: Vec<String>,
+    /// Force removal
+    force: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextRmCommand {
+    /// Create a new context rm command
+    #[must_use]
+    pub fn new(context: impl Into<String>) -> Self {
+        Self {
+            contexts: vec![context.into()],
+            force: false,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Add another context to remove
+    #[must_use]
+    pub fn add_context(mut self, context: impl Into<String>) -> Self {
+        self.contexts.push(context.into());
+        self
+    }
+
+    /// Force removal (don't prompt for confirmation)
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextRmCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "rm".to_string()];
+
+        if self.force {
+            args.push("--force".to_string());
+        }
+
+        args.extend(self.contexts.clone());
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+/// Extension methods for `ContextRmCommand` output
+impl CommandOutput {
+    /// Get removed context names from output
+    #[must_use]
+    pub fn removed_contexts(&self) -> Vec<String> {
+        self.stdout
+            .lines()
+            .filter_map(|line| {
+                if line.is_empty() {
+                    None
+                } else {
+                    Some(line.trim().to_string())
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_rm_single() {
+        let cmd = ContextRmCommand::new("test-context");
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "rm");
+        assert!(args.contains(&"test-context".to_string()));
+    }
+
+    #[test]
+    fn test_context_rm_multiple() {
+        let cmd = ContextRmCommand::new("context1").add_context("context2");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"context1".to_string()));
+        assert!(args.contains(&"context2".to_string()));
+    }
+
+    #[test]
+    fn test_context_rm_force() {
+        let cmd = ContextRmCommand::new("test-context").force();
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--force".to_string()));
+    }
+
+    #[test]
+    fn test_removed_contexts_parsing() {
+        let output = CommandOutput {
+            stdout: "context1\ncontext2\n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+
+        let removed = output.removed_contexts();
+        assert_eq!(removed.len(), 2);
+        assert_eq!(removed[0], "context1");
+        assert_eq!(removed[1], "context2");
+    }
+}

--- a/src/command/context/update.rs
+++ b/src/command/context/update.rs
@@ -1,0 +1,219 @@
+//! Docker context update command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker context update command builder
+///
+/// Update an existing Docker context.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextUpdateCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Update a context's description
+/// ContextUpdateCommand::new("production")
+///     .description("Updated production environment")
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextUpdateCommand {
+    /// Context name to update
+    name: String,
+    /// New description
+    description: Option<String>,
+    /// New Docker host
+    docker_host: Option<String>,
+    /// New default stack orchestrator
+    default_stack_orchestrator: Option<String>,
+    /// New Docker API endpoint
+    docker_api_endpoint: Option<String>,
+    /// New Kubernetes config file
+    kubernetes_config_file: Option<String>,
+    /// New Kubernetes context
+    kubernetes_context: Option<String>,
+    /// New Kubernetes namespace
+    kubernetes_namespace: Option<String>,
+    /// New Kubernetes API endpoint
+    kubernetes_api_endpoint: Option<String>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextUpdateCommand {
+    /// Create a new context update command
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            docker_host: None,
+            default_stack_orchestrator: None,
+            docker_api_endpoint: None,
+            kubernetes_config_file: None,
+            kubernetes_context: None,
+            kubernetes_namespace: None,
+            kubernetes_api_endpoint: None,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Update context description
+    #[must_use]
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Update Docker host
+    #[must_use]
+    pub fn docker_host(mut self, host: impl Into<String>) -> Self {
+        self.docker_host = Some(host.into());
+        self
+    }
+
+    /// Update default stack orchestrator (swarm|kubernetes|all)
+    #[must_use]
+    pub fn default_stack_orchestrator(mut self, orchestrator: impl Into<String>) -> Self {
+        self.default_stack_orchestrator = Some(orchestrator.into());
+        self
+    }
+
+    /// Update Docker API endpoint
+    #[must_use]
+    pub fn docker_api_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.docker_api_endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Update Kubernetes config file
+    #[must_use]
+    pub fn kubernetes_config_file(mut self, file: impl Into<String>) -> Self {
+        self.kubernetes_config_file = Some(file.into());
+        self
+    }
+
+    /// Update Kubernetes context
+    #[must_use]
+    pub fn kubernetes_context(mut self, context: impl Into<String>) -> Self {
+        self.kubernetes_context = Some(context.into());
+        self
+    }
+
+    /// Update Kubernetes namespace
+    #[must_use]
+    pub fn kubernetes_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.kubernetes_namespace = Some(namespace.into());
+        self
+    }
+
+    /// Update Kubernetes API endpoint
+    #[must_use]
+    pub fn kubernetes_api_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.kubernetes_api_endpoint = Some(endpoint.into());
+        self
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextUpdateCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "update".to_string()];
+
+        if let Some(desc) = &self.description {
+            args.push("--description".to_string());
+            args.push(desc.clone());
+        }
+
+        if let Some(host) = &self.docker_host {
+            args.push("--docker".to_string());
+            args.push(format!("host={host}"));
+        }
+
+        if let Some(orchestrator) = &self.default_stack_orchestrator {
+            args.push("--default-stack-orchestrator".to_string());
+            args.push(orchestrator.clone());
+        }
+
+        if let Some(endpoint) = &self.docker_api_endpoint {
+            args.push("--docker".to_string());
+            args.push(format!("api-endpoint={endpoint}"));
+        }
+
+        if let Some(file) = &self.kubernetes_config_file {
+            args.push("--kubernetes".to_string());
+            args.push(format!("config-file={file}"));
+        }
+
+        if let Some(context) = &self.kubernetes_context {
+            args.push("--kubernetes".to_string());
+            args.push(format!("context={context}"));
+        }
+
+        if let Some(namespace) = &self.kubernetes_namespace {
+            args.push("--kubernetes".to_string());
+            args.push(format!("namespace={namespace}"));
+        }
+
+        if let Some(endpoint) = &self.kubernetes_api_endpoint {
+            args.push("--kubernetes".to_string());
+            args.push(format!("api-endpoint={endpoint}"));
+        }
+
+        args.push(self.name.clone());
+
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_update_basic() {
+        let cmd = ContextUpdateCommand::new("test-context");
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "update");
+        assert!(args.contains(&"test-context".to_string()));
+    }
+
+    #[test]
+    fn test_context_update_with_description() {
+        let cmd = ContextUpdateCommand::new("test-context").description("Updated description");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--description".to_string()));
+        assert!(args.contains(&"Updated description".to_string()));
+    }
+
+    #[test]
+    fn test_context_update_with_docker_host() {
+        let cmd = ContextUpdateCommand::new("remote").docker_host("tcp://127.0.0.1:2376");
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"--docker".to_string()));
+        assert!(args.contains(&"host=tcp://127.0.0.1:2376".to_string()));
+    }
+}

--- a/src/command/context/update.rs
+++ b/src/command/context/update.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextUpdateCommand;
+/// use docker_wrapper::{ContextUpdateCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Update a context's description

--- a/src/command/context/use_context.rs
+++ b/src/command/context/use_context.rs
@@ -1,0 +1,115 @@
+//! Docker context use command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Docker context use command builder
+///
+/// Switch to a different Docker context.
+///
+/// # Example
+///
+/// ```no_run
+/// use docker_wrapper::command::context::ContextUseCommand;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Switch to production context
+/// ContextUseCommand::new("production")
+///     .execute()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ContextUseCommand {
+    /// Context name to switch to
+    name: String,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl ContextUseCommand {
+    /// Create a new context use command
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            executor: CommandExecutor::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl DockerCommand for ContextUseCommand {
+    type Output = CommandOutput;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        let mut args = vec!["context".to_string(), "use".to_string(), self.name.clone()];
+
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_command_args();
+        self.execute_command(args).await
+    }
+}
+
+/// Extension methods for `ContextUseCommand` output
+impl CommandOutput {
+    /// Check if context switch was successful
+    #[must_use]
+    pub fn context_switched(&self) -> bool {
+        self.exit_code == 0 && self.stderr.is_empty()
+    }
+
+    /// Get the name of the context that was switched to
+    pub fn switched_to_context(&self) -> Option<String> {
+        if self.context_switched() {
+            // The output typically contains the context name
+            self.stdout.split_whitespace().last().map(String::from)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_use_basic() {
+        let cmd = ContextUseCommand::new("production");
+        let args = cmd.build_command_args();
+        assert_eq!(args[0], "context");
+        assert_eq!(args[1], "use");
+        assert_eq!(args[2], "production");
+    }
+
+    #[test]
+    fn test_context_switched() {
+        let output = CommandOutput {
+            stdout: "Current context is now \"production\"".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            success: true,
+        };
+
+        assert!(output.context_switched());
+        assert_eq!(
+            output.switched_to_context(),
+            Some("\"production\"".to_string())
+        );
+    }
+}

--- a/src/command/context/use_context.rs
+++ b/src/command/context/use_context.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 /// # Example
 ///
 /// ```no_run
-/// use docker_wrapper::command::context::ContextUseCommand;
+/// use docker_wrapper::{ContextUseCommand, DockerCommand};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Switch to production context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,10 @@ pub use command::{
     builder::{BuilderBuildCommand, BuilderPruneCommand, BuilderPruneResult},
     commit::{CommitCommand, CommitResult},
     container_prune::{ContainerPruneCommand, ContainerPruneResult},
+    context::{
+        ContextCreateCommand, ContextInspectCommand, ContextLsCommand, ContextRmCommand,
+        ContextUpdateCommand, ContextUseCommand,
+    },
     cp::{CpCommand, CpResult},
     create::{CreateCommand, CreateResult},
     diff::{DiffCommand, DiffResult, FilesystemChange, FilesystemChangeType},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,8 +387,8 @@ pub use command::{
     commit::{CommitCommand, CommitResult},
     container_prune::{ContainerPruneCommand, ContainerPruneResult},
     context::{
-        ContextCreateCommand, ContextInspectCommand, ContextLsCommand, ContextRmCommand,
-        ContextUpdateCommand, ContextUseCommand,
+        ContextCreateCommand, ContextInfo, ContextInspectCommand, ContextLsCommand,
+        ContextRmCommand, ContextUpdateCommand, ContextUseCommand,
     },
     cp::{CpCommand, CpResult},
     create::{CreateCommand, CreateResult},

--- a/tests/context_integration.rs
+++ b/tests/context_integration.rs
@@ -1,0 +1,177 @@
+//! Integration tests for Docker context commands
+
+use docker_wrapper::command::context::{
+    ContextCreateCommand, ContextInspectCommand, ContextLsCommand, ContextRmCommand,
+    ContextUpdateCommand, ContextUseCommand,
+};
+use docker_wrapper::DockerCommand;
+
+#[tokio::test]
+async fn test_context_ls_command() {
+    let ls_cmd = ContextLsCommand::new().quiet();
+
+    let args = ls_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"ls".to_string()));
+    assert!(args.contains(&"--quiet".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_ls_with_format() {
+    let ls_cmd = ContextLsCommand::new().format("{{.Name}}");
+
+    let args = ls_cmd.build_command_args();
+    assert!(args.contains(&"--format".to_string()));
+    assert!(args.contains(&"{{.Name}}".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_create_command() {
+    let create_cmd = ContextCreateCommand::new("test-context")
+        .description("Test context for integration testing")
+        .docker_host("unix:///var/run/docker.sock");
+
+    let args = create_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"create".to_string()));
+    assert!(args.contains(&"test-context".to_string()));
+    assert!(args.contains(&"--description".to_string()));
+    assert!(args.contains(&"Test context for integration testing".to_string()));
+    assert!(args.contains(&"--docker".to_string()));
+    assert!(args.contains(&"host=unix:///var/run/docker.sock".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_create_from_existing() {
+    let create_cmd = ContextCreateCommand::new("new-context")
+        .from("default")
+        .description("Created from default");
+
+    let args = create_cmd.build_command_args();
+    assert!(args.contains(&"--from".to_string()));
+    assert!(args.contains(&"default".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_use_command() {
+    let use_cmd = ContextUseCommand::new("production");
+
+    let args = use_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"use".to_string()));
+    assert!(args.contains(&"production".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_inspect_command() {
+    let inspect_cmd = ContextInspectCommand::new("default").format("{{.Endpoints.docker.Host}}");
+
+    let args = inspect_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"inspect".to_string()));
+    assert!(args.contains(&"default".to_string()));
+    assert!(args.contains(&"--format".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_inspect_multiple() {
+    let inspect_cmd = ContextInspectCommand::new("context1").add_context("context2");
+
+    let args = inspect_cmd.build_command_args();
+    assert!(args.contains(&"context1".to_string()));
+    assert!(args.contains(&"context2".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_update_command() {
+    let update_cmd = ContextUpdateCommand::new("test-context")
+        .description("Updated description")
+        .docker_host("tcp://127.0.0.1:2376");
+
+    let args = update_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"update".to_string()));
+    assert!(args.contains(&"test-context".to_string()));
+    assert!(args.contains(&"--description".to_string()));
+    assert!(args.contains(&"Updated description".to_string()));
+    assert!(args.contains(&"--docker".to_string()));
+    assert!(args.contains(&"host=tcp://127.0.0.1:2376".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_rm_command() {
+    let rm_cmd = ContextRmCommand::new("test-context").force();
+
+    let args = rm_cmd.build_command_args();
+    assert!(args.contains(&"context".to_string()));
+    assert!(args.contains(&"rm".to_string()));
+    assert!(args.contains(&"test-context".to_string()));
+    assert!(args.contains(&"--force".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_rm_multiple() {
+    let rm_cmd = ContextRmCommand::new("context1")
+        .add_context("context2")
+        .add_context("context3");
+
+    let args = rm_cmd.build_command_args();
+    assert!(args.contains(&"context1".to_string()));
+    assert!(args.contains(&"context2".to_string()));
+    assert!(args.contains(&"context3".to_string()));
+}
+
+#[tokio::test]
+async fn test_context_lifecycle() {
+    // Test a complete lifecycle of context operations
+    // Note: This test requires Docker to be available
+    let context_name = format!("test-context-{}", uuid::Uuid::new_v4());
+
+    // List existing contexts
+    let ls_result = ContextLsCommand::new().quiet().execute().await;
+
+    if ls_result.is_err() {
+        eprintln!("Skipping test - Docker not available");
+        return;
+    }
+
+    // Create a new context
+    let create_result = ContextCreateCommand::new(&context_name)
+        .description("Test context for automated testing")
+        .from("default")
+        .execute()
+        .await;
+
+    if create_result.is_ok() {
+        // Inspect the created context
+        let inspect_result = ContextInspectCommand::new(&context_name).execute().await;
+        assert!(inspect_result.is_ok());
+
+        // Update the context
+        let update_result = ContextUpdateCommand::new(&context_name)
+            .description("Updated test context")
+            .execute()
+            .await;
+        assert!(update_result.is_ok());
+
+        // Remove the context
+        let rm_result = ContextRmCommand::new(&context_name).force().execute().await;
+        assert!(rm_result.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod uuid {
+    pub struct Uuid;
+    impl Uuid {
+        pub fn new_v4() -> String {
+            format!(
+                "{:x}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement comprehensive Docker context management support
- Add commands for ls, create, use, inspect, update, and rm operations
- Support for both Docker and Kubernetes endpoints

## Features
- **ContextLsCommand**: List all Docker contexts with filtering and formatting options
- **ContextCreateCommand**: Create new contexts with Docker/Kubernetes configuration
- **ContextUseCommand**: Switch between contexts seamlessly  
- **ContextInspectCommand**: View detailed context information
- **ContextUpdateCommand**: Modify existing context configurations
- **ContextRmCommand**: Remove contexts with force option

## API Design
All commands follow the established builder pattern:
```rust
// Create a new context
ContextCreateCommand::new("production")
    .description("Production environment")
    .docker_host("ssh://user@remote-host")
    .execute()
    .await?;

// Switch contexts
ContextUseCommand::new("production")
    .execute()
    .await?;

// List contexts
ContextLsCommand::new()
    .format_json()
    .execute()
    .await?;
```

## Testing
- Comprehensive unit tests for all command builders
- Integration tests covering the full context lifecycle
- Helper methods for parsing command outputs

## Checklist
- [x] Implements all context subcommands
- [x] Follows existing builder pattern conventions
- [x] Includes comprehensive tests
- [x] Documentation with examples
- [x] All tests passing
- [x] Clippy and formatting checks pass