### PR TITLE
fix: install cargo-machete and cargo-outdated in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,16 +242,31 @@ jobs:
           cache-directories: |
             ~/.cargo/bin/
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+      - name: Cache cargo-machete
+        id: cache-cargo-machete
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-machete
+          key: cargo-machete-${{ runner.os }}
 
-      - name: Install dependency tools with binstall
-        run: |
-          cargo binstall cargo-machete cargo-outdated --no-confirm --locked
+      - name: Install cargo-machete if not cached
+        if: steps.cache-cargo-machete.outputs.cache-hit != 'true'
+        run: cargo install cargo-machete --locked
 
       - name: Check for unused dependencies
         run: cargo machete
         continue-on-error: true
+
+      - name: Cache cargo-outdated
+        id: cache-cargo-outdated
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-outdated
+          key: cargo-outdated-${{ runner.os }}
+
+      - name: Install cargo-outdated if not cached
+        if: steps.cache-cargo-outdated.outputs.cache-hit != 'true'
+        run: cargo install cargo-outdated --locked
 
       - name: Check for outdated dependencies
         run: cargo outdated --exit-code 1 || true


### PR DESCRIPTION
## Summary
This PR fixes the CI failure where cargo-machete didn't find any unused dependencies in this directory. Good job! command was not found.

## Problem
The CI workflow was trying to use  to install cargo-machete didn't find any unused dependencies in this directory. Good job! and , but this was failing with:


## Solution
- Replace  with direct  commands
- Add proper caching for both tools to avoid reinstalling on every run
- Use the same caching pattern as other tools in the workflow (cargo-audit, cargo-tarpaulin)

## Benefits
- More reliable dependency checking in CI
- Faster CI runs due to binary caching
- Consistent with other tool installations in the workflow

## Testing
- ✅ Pre-push checks pass locally
- ✅ All tests pass
- ✅ Formatting and clippy clean