### PR TITLE
fix: remove invalid field from release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -33,6 +33,3 @@ git_tag_name = "v{{ version }}"
 # Enable changelog updates for version detection
 changelog_update = true
 changelog_path = "CHANGELOG.md"
-
-# Customize changelog format
-changelog_config = "cliff.toml"


### PR DESCRIPTION
Fixes the invalid changelog_config field that was causing release-plz to fail. This field doesn't exist in the release-plz configuration format.