### PR TITLE
docs: clarify DockerCommand trait requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Container started: {}", output.container_id);
+    println!("Container started: {}", output.0);
     Ok(())
 }
 ```
+
+> **Important:** The `DockerCommand` trait must be imported to use the `.execute()` method on any Docker command. This trait provides the core execution functionality for all commands.
 
 ### Docker Builder Example
 


### PR DESCRIPTION
## Summary
Clarify that the `DockerCommand` trait must be imported to use `.execute()` method on Docker commands.

## Motivation
Users were getting compilation errors:
```
error[E0599]: no method named `execute` found for struct `RunCommand`
```

This happens because the `DockerCommand` trait provides the `.execute()` method, but users may not realize they need to import it.

## Changes
1. Added explicit note in README after Quick Start example explaining the trait requirement
2. Fixed incorrect `output.container_id` to `output.0` in Quick Start (RunCommand returns ContainerId directly)

## Impact
This documentation improvement will help new users avoid the common "no method named execute" error and understand the trait-based design of docker-wrapper.