### PR TITLE
fix: enable all features for docs.rs to show template documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ categories = ["development-tools", "api-bindings"]
 homepage = "https://github.com/joshrotenberg/docker-wrapper"
 documentation = "https://docs.rs/docker-wrapper"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = []
 compose = []


### PR DESCRIPTION
## Summary
- Add `package.metadata.docs.rs` configuration to Cargo.toml
- Enable `all-features` flag for docs.rs builds
- Add `rustdoc-args` for docsrs cfg flag

## Problem
Template documentation was not visible on docs.rs because the optional template features weren't being enabled during documentation generation. This meant users couldn't discover or access template documentation on the published docs.

## Solution
Configure docs.rs to build with all features enabled via `package.metadata.docs.rs` section in Cargo.toml. This ensures all template modules and their comprehensive documentation are visible on docs.rs.

## Test plan
- [x] Verified all unit tests pass
- [x] Verified all integration tests pass
- [x] Generated local documentation to confirm template visibility
- [x] Pre-push hooks validated code quality

After merge, template documentation should be fully visible at https://docs.rs/docker-wrapper including:
- Template module with comprehensive examples
- Individual template structs with detailed usage documentation
- All Redis, database, and web server template variants