### PR TITLE
fix: use container hostnames for Redis cluster initialization

### DIFF
--- a/src/template/redis/cluster.rs
+++ b/src/template/redis/cluster.rs
@@ -309,10 +309,10 @@ impl RedisClusterTemplate {
             "create".to_string(),
         ];
 
-        // Add all node addresses
-        let host = self.announce_ip.as_deref().unwrap_or("127.0.0.1");
+        // Add all node addresses using container hostnames (internal port is always 6379)
         for i in 0..self.total_nodes() {
-            let port = self.port_base + i as u16;
+            let host = format!("{}-node-{}", self.name, i);
+            let port = 6379;
             create_args.push(format!("{}:{}", host, port));
         }
 
@@ -349,11 +349,7 @@ impl RedisClusterTemplate {
             "redis-cli".to_string(),
             "--cluster".to_string(),
             "info".to_string(),
-            format!(
-                "{}:{}",
-                self.announce_ip.as_deref().unwrap_or("127.0.0.1"),
-                self.port_base
-            ),
+            format!("{}-node-0:6379", self.name),
         ];
 
         if let Some(ref password) = self.password {


### PR DESCRIPTION
When running cluster initialization from inside a container (via docker exec), the cluster create command needs to use container hostnames instead of 127.0.0.1 or external IPs.

Changes:
- Use container hostnames ({name}-node-{i}) instead of announce_ip/127.0.0.1
- Use internal port 6379 instead of port_base + offset
- Fixes cluster initialization failure where nodes couldn't communicate

The announce_ip option is still used for cluster-announce-ip (external access) but cluster initialization now happens via internal Docker networking.