### PR TITLE
fix: use which crate for cross-platform Docker binary lookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ async-trait = "0.1"
 # Optional dependencies for templates
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], optional = true }
 
+# Cross-platform binary lookup
+which = "8.0"
+
 [dev-dependencies]
 tokio-test = "0.4"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
## Summary

Replace shell-based `which docker` command with the `which` crate for cross-platform compatibility.

## Problem

Windows users encountered "Failed to run 'which docker': program not found" errors (issue #166) because the `which` command is Unix-only.

## Solution

Use the `which` crate (already a dev-dependency, now promoted to regular dependency) for reliable binary lookup on both Unix and Windows systems.

## Changes

- Added `which = "8.0"` as a regular dependency
- Simplified `find_docker_binary()` from an async shell command to a synchronous crate call
- Proper error handling with `Error::DockerNotFound`

## Testing

- All 756 unit tests pass
- Integration tests pass (one pre-existing flaky test unrelated to this change)
- Clippy clean

Closes #166

---

Inspired by @davehorner's work in #167 - thank you for identifying this issue and proposing the `which` crate approach!