### PR TITLE
fix: improve template reliability on slower systems

### DIFF
--- a/src/template/database/mongodb.rs
+++ b/src/template/database/mongodb.rs
@@ -284,16 +284,17 @@ impl Template for MongodbTemplate {
         use tokio::time::{sleep, timeout};
 
         // Custom MongoDB readiness check
-        let wait_timeout = Duration::from_secs(30);
+        // Use 60 second timeout for slower systems (especially Windows)
+        let wait_timeout = Duration::from_secs(60);
         let check_interval = Duration::from_millis(500);
 
         timeout(wait_timeout, async {
             loop {
-                // First check if container is running
-                if !self.is_running().await? {
-                    return Err(crate::template::TemplateError::NotRunning(
-                        self.config().name.clone(),
-                    ));
+                // Check if container is running - keep retrying if not yet started
+                // Don't fail immediately as the container may still be starting up
+                if !self.is_running().await.unwrap_or(false) {
+                    sleep(check_interval).await;
+                    continue;
                 }
 
                 // Try to connect to MongoDB using mongosh (or mongo for older versions)

--- a/src/template/redis/basic.rs
+++ b/src/template/redis/basic.rs
@@ -154,16 +154,17 @@ impl Template for RedisTemplate {
         use tokio::time::{sleep, timeout};
 
         // Custom Redis readiness check
-        let wait_timeout = Duration::from_secs(30);
+        // Use 60 second timeout for slower systems (especially Windows)
+        let wait_timeout = Duration::from_secs(60);
         let check_interval = Duration::from_millis(500);
 
         timeout(wait_timeout, async {
             loop {
-                // First check if container is running
-                if !self.is_running().await? {
-                    return Err(crate::template::TemplateError::NotRunning(
-                        self.config().name.clone(),
-                    ));
+                // Check if container is running - keep retrying if not yet started
+                // Don't fail immediately as the container may still be starting up
+                if !self.is_running().await.unwrap_or(false) {
+                    sleep(check_interval).await;
+                    continue;
                 }
 
                 // Try to ping Redis


### PR DESCRIPTION
## Summary

Fixes reliability issues with templates on slower systems (especially Windows) reported in #168.

## Problems Fixed

### 1. Race condition in `wait_for_ready()`

All template implementations (Redis, PostgreSQL, MySQL, MongoDB, and base) were failing immediately with `NotRunning` error if `is_running()` returned false. On slower systems (especially Windows), the container may still be starting up when this check runs.

**Before:** Container starts -> immediate `is_running()` check -> fails with `NotRunning`
**After:** Container starts -> retry `is_running()` until true or timeout

### 2. Container name conflicts in `template_showcase` example

The example used fixed container names like `showcase-redis`, `showcase-postgres`, etc., but only added UUIDs to volumes and networks. If the example crashed mid-way, containers were left behind and the next run failed with "container name already in use".

**Fix:** Now uses unique UUIDs for container names, matching the pattern already used for volumes and networks.

## Changes

- **src/template/mod.rs**: Base `wait_for_ready()` now retries on `is_running() == false`
- **src/template/redis/basic.rs**: Same fix for Redis template
- **src/template/database/postgres.rs**: Same fix for PostgreSQL template  
- **src/template/database/mysql.rs**: Same fix for MySQL template
- **src/template/database/mongodb.rs**: Same fix for MongoDB template
- **examples/template_showcase.rs**: Use unique container names, fix inter-container test
- Increased default timeout from 30s to 60s for all templates

## Testing

- All 756 unit tests pass
- Clippy clean

Closes #168

Thanks to @davehorner for the detailed bug report!