### PR TITLE
feat: add configurable timeouts for command execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,12 +537,15 @@ pub use command::{
     },
     wait::{WaitCommand, WaitResult},
     CommandExecutor, CommandOutput, DockerCommand, EnvironmentBuilder, PortBuilder, PortMapping,
-    Protocol,
+    Protocol, DEFAULT_COMMAND_TIMEOUT,
 };
 pub use debug::{BackoffStrategy, DebugConfig, DebugExecutor, DryRunPreview, RetryPolicy};
 pub use error::{Error, Result};
 pub use platform::{Platform, PlatformInfo, Runtime};
-pub use prerequisites::{ensure_docker, DockerInfo, DockerPrerequisites};
+pub use prerequisites::{
+    ensure_docker, ensure_docker_with_timeout, DockerInfo, DockerPrerequisites,
+    DEFAULT_PREREQ_TIMEOUT,
+};
 
 #[cfg(any(
     feature = "templates",


### PR DESCRIPTION
## Summary

Add optional timeout support for Docker command execution and prerequisite checks. This prevents commands from hanging indefinitely when the Docker daemon is unresponsive or experiencing issues.

## Background

Reported by @davehorner in #167 - Docker commands like `docker version` and `docker info` can hang indefinitely in certain situations. This was also tracked in #187.

## API

### CommandExecutor
```rust
// Set timeout on the executor
let executor = CommandExecutor::new()
    .timeout(Duration::from_secs(10));
```

### DockerCommand trait (available on all commands)
```rust
// Any command can have a timeout
let result = VersionCommand::new()
    .with_timeout_secs(10)
    .execute()
    .await?;

let containers = PsCommand::new()
    .with_timeout(Duration::from_secs(30))
    .execute()
    .await?;
```

### DockerPrerequisites
```rust
// Prerequisites check with timeout
let info = DockerPrerequisites::default()
    .with_timeout_secs(15)
    .check()
    .await?;

// Or use the convenience function
let info = ensure_docker_with_timeout(Duration::from_secs(10)).await?;
```

### Constants
- `DEFAULT_COMMAND_TIMEOUT` - 30 seconds (for reference, not enforced by default)
- `DEFAULT_PREREQ_TIMEOUT` - 30 seconds (for reference, not enforced by default)

## Design Decisions

1. **Opt-in timeouts**: By default, commands have no timeout (current behavior preserved). Users must explicitly set a timeout.

2. **Per-command granularity**: Each command can have its own timeout, allowing fine-grained control.

3. **Error type**: Uses existing `Error::Timeout { timeout_seconds }` for timeout errors.

## Testing

- Added unit tests for timeout configuration
- All 758 tests pass
- Clippy clean

Closes #187