### PR TITLE
feat: add Docker Swarm command support

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -73,6 +73,7 @@ pub mod search;
 pub mod start;
 pub mod stats;
 pub mod stop;
+pub mod swarm;
 pub mod system;
 pub mod tag;
 pub mod top;

--- a/src/command/swarm/ca.rs
+++ b/src/command/swarm/ca.rs
@@ -1,0 +1,227 @@
+//! Docker swarm ca command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm ca command
+#[derive(Debug, Clone)]
+pub struct SwarmCaResult {
+    /// The CA certificate (PEM format)
+    pub certificate: Option<String>,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmCaResult {
+    /// Parse the swarm ca output
+    fn parse(output: &CommandOutput) -> Self {
+        let stdout = output.stdout.trim();
+
+        // Check if output looks like a PEM certificate
+        let certificate = if stdout.contains("-----BEGIN CERTIFICATE-----") {
+            Some(stdout.to_string())
+        } else {
+            None
+        };
+
+        Self {
+            certificate,
+            output: stdout.to_string(),
+        }
+    }
+}
+
+/// Docker swarm ca command builder
+///
+/// Display and rotate the root CA certificate.
+#[derive(Debug, Clone, Default)]
+pub struct SwarmCaCommand {
+    /// Path to the PEM-formatted root CA certificate to use
+    ca_cert: Option<String>,
+    /// Path to the PEM-formatted root CA key to use
+    ca_key: Option<String>,
+    /// Validity period for node certificates (ns|us|ms|s|m|h)
+    cert_expiry: Option<String>,
+    /// Exit immediately instead of waiting for rotation to complete
+    detach: bool,
+    /// Specifications of external CA to use
+    external_ca: Option<String>,
+    /// Suppress progress output
+    quiet: bool,
+    /// Rotate the swarm CA (creates new cluster TLS certs)
+    rotate: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmCaCommand {
+    /// Create a new swarm ca command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the path to the root CA certificate
+    #[must_use]
+    pub fn ca_cert(mut self, path: impl Into<String>) -> Self {
+        self.ca_cert = Some(path.into());
+        self
+    }
+
+    /// Set the path to the root CA key
+    #[must_use]
+    pub fn ca_key(mut self, path: impl Into<String>) -> Self {
+        self.ca_key = Some(path.into());
+        self
+    }
+
+    /// Set the certificate expiry duration
+    #[must_use]
+    pub fn cert_expiry(mut self, expiry: impl Into<String>) -> Self {
+        self.cert_expiry = Some(expiry.into());
+        self
+    }
+
+    /// Exit immediately instead of waiting for rotation to complete
+    #[must_use]
+    pub fn detach(mut self) -> Self {
+        self.detach = true;
+        self
+    }
+
+    /// Set external CA specifications
+    #[must_use]
+    pub fn external_ca(mut self, spec: impl Into<String>) -> Self {
+        self.external_ca = Some(spec.into());
+        self
+    }
+
+    /// Suppress progress output
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    /// Rotate the swarm CA
+    #[must_use]
+    pub fn rotate(mut self) -> Self {
+        self.rotate = true;
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "ca".to_string()];
+
+        if let Some(ref path) = self.ca_cert {
+            args.push("--ca-cert".to_string());
+            args.push(path.clone());
+        }
+
+        if let Some(ref path) = self.ca_key {
+            args.push("--ca-key".to_string());
+            args.push(path.clone());
+        }
+
+        if let Some(ref expiry) = self.cert_expiry {
+            args.push("--cert-expiry".to_string());
+            args.push(expiry.clone());
+        }
+
+        if self.detach {
+            args.push("--detach".to_string());
+        }
+
+        if let Some(ref spec) = self.external_ca {
+            args.push("--external-ca".to_string());
+            args.push(spec.clone());
+        }
+
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        if self.rotate {
+            args.push("--rotate".to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmCaCommand {
+    type Output = SwarmCaResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmCaResult::parse(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_ca_basic() {
+        let cmd = SwarmCaCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "ca"]);
+    }
+
+    #[test]
+    fn test_swarm_ca_rotate() {
+        let cmd = SwarmCaCommand::new().rotate();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--rotate".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_ca_with_cert_and_key() {
+        let cmd = SwarmCaCommand::new()
+            .ca_cert("/path/to/cert.pem")
+            .ca_key("/path/to/key.pem");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--ca-cert".to_string()));
+        assert!(args.contains(&"/path/to/cert.pem".to_string()));
+        assert!(args.contains(&"--ca-key".to_string()));
+        assert!(args.contains(&"/path/to/key.pem".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_ca_all_options() {
+        let cmd = SwarmCaCommand::new()
+            .ca_cert("/cert.pem")
+            .ca_key("/key.pem")
+            .cert_expiry("90d")
+            .detach()
+            .external_ca("protocol=cfssl,url=https://ca.example.com")
+            .quiet()
+            .rotate();
+
+        let args = cmd.build_args();
+        assert!(args.contains(&"--ca-cert".to_string()));
+        assert!(args.contains(&"--ca-key".to_string()));
+        assert!(args.contains(&"--cert-expiry".to_string()));
+        assert!(args.contains(&"--detach".to_string()));
+        assert!(args.contains(&"--external-ca".to_string()));
+        assert!(args.contains(&"--quiet".to_string()));
+        assert!(args.contains(&"--rotate".to_string()));
+    }
+}

--- a/src/command/swarm/init.rs
+++ b/src/command/swarm/init.rs
@@ -1,0 +1,385 @@
+//! Docker swarm init command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm init command
+#[derive(Debug, Clone)]
+pub struct SwarmInitResult {
+    /// The node ID of the manager node
+    pub node_id: Option<String>,
+    /// The worker join token
+    pub worker_token: Option<String>,
+    /// The manager join token
+    pub manager_token: Option<String>,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmInitResult {
+    /// Parse the swarm init output
+    fn parse(output: &CommandOutput) -> Self {
+        let stdout = &output.stdout;
+
+        // Try to extract tokens from the output
+        // Output format:
+        // Swarm initialized: current node (nodeId) is now a manager.
+        // To add a worker to this swarm, run the following command:
+        //     docker swarm join --token <token> <ip>:<port>
+
+        let mut node_id = None;
+        let mut worker_token = None;
+        let mut manager_token = None;
+
+        for line in stdout.lines() {
+            if line.contains("current node") && line.contains("is now a manager") {
+                // Extract node ID from parentheses
+                if let Some(start) = line.find('(') {
+                    if let Some(end) = line.find(')') {
+                        node_id = Some(line[start + 1..end].to_string());
+                    }
+                }
+            }
+
+            if line.contains("--token") {
+                // Extract token from the join command
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                for (i, part) in parts.iter().enumerate() {
+                    if *part == "--token" {
+                        if let Some(token) = parts.get(i + 1) {
+                            // Determine if this is worker or manager token based on context
+                            if stdout.contains("add a worker") && worker_token.is_none() {
+                                worker_token = Some((*token).to_string());
+                            } else if stdout.contains("add a manager") {
+                                manager_token = Some((*token).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Self {
+            node_id,
+            worker_token,
+            manager_token,
+            output: stdout.clone(),
+        }
+    }
+}
+
+/// Docker swarm init command builder
+#[derive(Debug, Clone, Default)]
+pub struct SwarmInitCommand {
+    /// Advertised address (format: <ip|interface>[:port])
+    advertise_addr: Option<String>,
+    /// Enable manager auto-lock
+    autolock: bool,
+    /// Availability of the node (active, pause, drain)
+    availability: Option<String>,
+    /// Validity period for node certificates (ns|us|ms|s|m|h)
+    cert_expiry: Option<String>,
+    /// Address or interface to use for data path traffic
+    data_path_addr: Option<String>,
+    /// Port to use for data path traffic
+    data_path_port: Option<u16>,
+    /// Default address pool in CIDR format
+    default_addr_pool: Vec<String>,
+    /// Default address pool subnet mask length
+    default_addr_pool_mask_length: Option<u8>,
+    /// Dispatcher heartbeat period (ns|us|ms|s|m|h)
+    dispatcher_heartbeat: Option<String>,
+    /// External CA URL (format: `protocol://url`)
+    external_ca: Option<String>,
+    /// Force create a new cluster from current state
+    force_new_cluster: bool,
+    /// Listen address (format: <ip|interface>[:port])
+    listen_addr: Option<String>,
+    /// Number of snapshots to keep beyond current snapshot
+    max_snapshots: Option<u32>,
+    /// Log entries to keep after compacting raft log
+    snapshot_interval: Option<u32>,
+    /// Task history retention limit
+    task_history_limit: Option<i32>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmInitCommand {
+    /// Create a new swarm init command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the advertised address
+    #[must_use]
+    pub fn advertise_addr(mut self, addr: impl Into<String>) -> Self {
+        self.advertise_addr = Some(addr.into());
+        self
+    }
+
+    /// Enable manager auto-lock
+    #[must_use]
+    pub fn autolock(mut self) -> Self {
+        self.autolock = true;
+        self
+    }
+
+    /// Set the availability of the node
+    #[must_use]
+    pub fn availability(mut self, availability: impl Into<String>) -> Self {
+        self.availability = Some(availability.into());
+        self
+    }
+
+    /// Set the certificate expiry duration
+    #[must_use]
+    pub fn cert_expiry(mut self, expiry: impl Into<String>) -> Self {
+        self.cert_expiry = Some(expiry.into());
+        self
+    }
+
+    /// Set the data path address
+    #[must_use]
+    pub fn data_path_addr(mut self, addr: impl Into<String>) -> Self {
+        self.data_path_addr = Some(addr.into());
+        self
+    }
+
+    /// Set the data path port
+    #[must_use]
+    pub fn data_path_port(mut self, port: u16) -> Self {
+        self.data_path_port = Some(port);
+        self
+    }
+
+    /// Add a default address pool
+    #[must_use]
+    pub fn default_addr_pool(mut self, pool: impl Into<String>) -> Self {
+        self.default_addr_pool.push(pool.into());
+        self
+    }
+
+    /// Set the default address pool mask length
+    #[must_use]
+    pub fn default_addr_pool_mask_length(mut self, length: u8) -> Self {
+        self.default_addr_pool_mask_length = Some(length);
+        self
+    }
+
+    /// Set the dispatcher heartbeat period
+    #[must_use]
+    pub fn dispatcher_heartbeat(mut self, heartbeat: impl Into<String>) -> Self {
+        self.dispatcher_heartbeat = Some(heartbeat.into());
+        self
+    }
+
+    /// Set the external CA URL
+    #[must_use]
+    pub fn external_ca(mut self, url: impl Into<String>) -> Self {
+        self.external_ca = Some(url.into());
+        self
+    }
+
+    /// Force create a new cluster from current state
+    #[must_use]
+    pub fn force_new_cluster(mut self) -> Self {
+        self.force_new_cluster = true;
+        self
+    }
+
+    /// Set the listen address
+    #[must_use]
+    pub fn listen_addr(mut self, addr: impl Into<String>) -> Self {
+        self.listen_addr = Some(addr.into());
+        self
+    }
+
+    /// Set the maximum number of snapshots to keep
+    #[must_use]
+    pub fn max_snapshots(mut self, count: u32) -> Self {
+        self.max_snapshots = Some(count);
+        self
+    }
+
+    /// Set the snapshot interval
+    #[must_use]
+    pub fn snapshot_interval(mut self, interval: u32) -> Self {
+        self.snapshot_interval = Some(interval);
+        self
+    }
+
+    /// Set the task history retention limit
+    #[must_use]
+    pub fn task_history_limit(mut self, limit: i32) -> Self {
+        self.task_history_limit = Some(limit);
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "init".to_string()];
+
+        if let Some(ref addr) = self.advertise_addr {
+            args.push("--advertise-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        if self.autolock {
+            args.push("--autolock".to_string());
+        }
+
+        if let Some(ref availability) = self.availability {
+            args.push("--availability".to_string());
+            args.push(availability.clone());
+        }
+
+        if let Some(ref expiry) = self.cert_expiry {
+            args.push("--cert-expiry".to_string());
+            args.push(expiry.clone());
+        }
+
+        if let Some(ref addr) = self.data_path_addr {
+            args.push("--data-path-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        if let Some(port) = self.data_path_port {
+            args.push("--data-path-port".to_string());
+            args.push(port.to_string());
+        }
+
+        for pool in &self.default_addr_pool {
+            args.push("--default-addr-pool".to_string());
+            args.push(pool.clone());
+        }
+
+        if let Some(length) = self.default_addr_pool_mask_length {
+            args.push("--default-addr-pool-mask-length".to_string());
+            args.push(length.to_string());
+        }
+
+        if let Some(ref heartbeat) = self.dispatcher_heartbeat {
+            args.push("--dispatcher-heartbeat".to_string());
+            args.push(heartbeat.clone());
+        }
+
+        if let Some(ref url) = self.external_ca {
+            args.push("--external-ca".to_string());
+            args.push(url.clone());
+        }
+
+        if self.force_new_cluster {
+            args.push("--force-new-cluster".to_string());
+        }
+
+        if let Some(ref addr) = self.listen_addr {
+            args.push("--listen-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        if let Some(count) = self.max_snapshots {
+            args.push("--max-snapshots".to_string());
+            args.push(count.to_string());
+        }
+
+        if let Some(interval) = self.snapshot_interval {
+            args.push("--snapshot-interval".to_string());
+            args.push(interval.to_string());
+        }
+
+        if let Some(limit) = self.task_history_limit {
+            args.push("--task-history-limit".to_string());
+            args.push(limit.to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmInitCommand {
+    type Output = SwarmInitResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmInitResult::parse(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_init_basic() {
+        let cmd = SwarmInitCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "init"]);
+    }
+
+    #[test]
+    fn test_swarm_init_with_advertise_addr() {
+        let cmd = SwarmInitCommand::new().advertise_addr("192.168.1.1:2377");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--advertise-addr".to_string()));
+        assert!(args.contains(&"192.168.1.1:2377".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_init_with_autolock() {
+        let cmd = SwarmInitCommand::new().autolock();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--autolock".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_init_all_options() {
+        let cmd = SwarmInitCommand::new()
+            .advertise_addr("192.168.1.1:2377")
+            .autolock()
+            .availability("active")
+            .cert_expiry("90d")
+            .data_path_addr("192.168.1.1")
+            .data_path_port(4789)
+            .default_addr_pool("10.10.0.0/16")
+            .default_addr_pool_mask_length(24)
+            .dispatcher_heartbeat("5s")
+            .force_new_cluster()
+            .listen_addr("0.0.0.0:2377")
+            .max_snapshots(5)
+            .snapshot_interval(10000)
+            .task_history_limit(10);
+
+        let args = cmd.build_args();
+        assert!(args.contains(&"--advertise-addr".to_string()));
+        assert!(args.contains(&"--autolock".to_string()));
+        assert!(args.contains(&"--availability".to_string()));
+        assert!(args.contains(&"--cert-expiry".to_string()));
+        assert!(args.contains(&"--data-path-addr".to_string()));
+        assert!(args.contains(&"--data-path-port".to_string()));
+        assert!(args.contains(&"--default-addr-pool".to_string()));
+        assert!(args.contains(&"--default-addr-pool-mask-length".to_string()));
+        assert!(args.contains(&"--dispatcher-heartbeat".to_string()));
+        assert!(args.contains(&"--force-new-cluster".to_string()));
+        assert!(args.contains(&"--listen-addr".to_string()));
+        assert!(args.contains(&"--max-snapshots".to_string()));
+        assert!(args.contains(&"--snapshot-interval".to_string()));
+        assert!(args.contains(&"--task-history-limit".to_string()));
+    }
+}

--- a/src/command/swarm/join.rs
+++ b/src/command/swarm/join.rs
@@ -1,0 +1,179 @@
+//! Docker swarm join command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm join command
+#[derive(Debug, Clone)]
+pub struct SwarmJoinResult {
+    /// Whether the join was successful
+    pub success: bool,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmJoinResult {
+    /// Parse the swarm join output
+    fn parse(output: &CommandOutput) -> Self {
+        Self {
+            success: output.success,
+            output: output.stdout.clone(),
+        }
+    }
+}
+
+/// Docker swarm join command builder
+#[derive(Debug, Clone)]
+pub struct SwarmJoinCommand {
+    /// The host:port of the manager to join
+    remote_addr: String,
+    /// Token for joining the swarm
+    token: String,
+    /// Advertised address (format: <ip|interface>[:port])
+    advertise_addr: Option<String>,
+    /// Availability of the node (active, pause, drain)
+    availability: Option<String>,
+    /// Address or interface to use for data path traffic
+    data_path_addr: Option<String>,
+    /// Listen address (format: <ip|interface>[:port])
+    listen_addr: Option<String>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmJoinCommand {
+    /// Create a new swarm join command
+    ///
+    /// # Arguments
+    /// * `token` - The join token (worker or manager)
+    /// * `remote_addr` - The address of a manager node (host:port)
+    #[must_use]
+    pub fn new(token: impl Into<String>, remote_addr: impl Into<String>) -> Self {
+        Self {
+            remote_addr: remote_addr.into(),
+            token: token.into(),
+            advertise_addr: None,
+            availability: None,
+            data_path_addr: None,
+            listen_addr: None,
+            executor: CommandExecutor::new(),
+        }
+    }
+
+    /// Set the advertised address
+    #[must_use]
+    pub fn advertise_addr(mut self, addr: impl Into<String>) -> Self {
+        self.advertise_addr = Some(addr.into());
+        self
+    }
+
+    /// Set the availability of the node
+    #[must_use]
+    pub fn availability(mut self, availability: impl Into<String>) -> Self {
+        self.availability = Some(availability.into());
+        self
+    }
+
+    /// Set the data path address
+    #[must_use]
+    pub fn data_path_addr(mut self, addr: impl Into<String>) -> Self {
+        self.data_path_addr = Some(addr.into());
+        self
+    }
+
+    /// Set the listen address
+    #[must_use]
+    pub fn listen_addr(mut self, addr: impl Into<String>) -> Self {
+        self.listen_addr = Some(addr.into());
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "join".to_string()];
+
+        if let Some(ref addr) = self.advertise_addr {
+            args.push("--advertise-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        if let Some(ref availability) = self.availability {
+            args.push("--availability".to_string());
+            args.push(availability.clone());
+        }
+
+        if let Some(ref addr) = self.data_path_addr {
+            args.push("--data-path-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        if let Some(ref addr) = self.listen_addr {
+            args.push("--listen-addr".to_string());
+            args.push(addr.clone());
+        }
+
+        // Token must come before remote address
+        args.push("--token".to_string());
+        args.push(self.token.clone());
+
+        // Remote address is the last positional argument
+        args.push(self.remote_addr.clone());
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmJoinCommand {
+    type Output = SwarmJoinResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmJoinResult::parse(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_join_basic() {
+        let cmd = SwarmJoinCommand::new("SWMTKN-1-xxx", "192.168.1.1:2377");
+        let args = cmd.build_args();
+        assert_eq!(args[0], "swarm");
+        assert_eq!(args[1], "join");
+        assert!(args.contains(&"--token".to_string()));
+        assert!(args.contains(&"SWMTKN-1-xxx".to_string()));
+        assert!(args.contains(&"192.168.1.1:2377".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_join_with_options() {
+        let cmd = SwarmJoinCommand::new("SWMTKN-1-xxx", "192.168.1.1:2377")
+            .advertise_addr("192.168.1.2:2377")
+            .availability("active")
+            .data_path_addr("192.168.1.2")
+            .listen_addr("0.0.0.0:2377");
+
+        let args = cmd.build_args();
+        assert!(args.contains(&"--advertise-addr".to_string()));
+        assert!(args.contains(&"--availability".to_string()));
+        assert!(args.contains(&"--data-path-addr".to_string()));
+        assert!(args.contains(&"--listen-addr".to_string()));
+    }
+}

--- a/src/command/swarm/join_token.rs
+++ b/src/command/swarm/join_token.rs
@@ -1,0 +1,245 @@
+//! Docker swarm join-token command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Node role for join token retrieval
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwarmNodeRole {
+    /// Worker node role
+    Worker,
+    /// Manager node role
+    Manager,
+}
+
+impl SwarmNodeRole {
+    /// Get the role as a string
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Worker => "worker",
+            Self::Manager => "manager",
+        }
+    }
+}
+
+impl std::fmt::Display for SwarmNodeRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Result of swarm join-token command
+#[derive(Debug, Clone)]
+pub struct SwarmJoinTokenResult {
+    /// The join token
+    pub token: Option<String>,
+    /// The full join command (if not using --quiet)
+    pub join_command: Option<String>,
+    /// The role for which the token was retrieved
+    pub role: SwarmNodeRole,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmJoinTokenResult {
+    /// Parse the swarm join-token output
+    fn parse(output: &CommandOutput, role: SwarmNodeRole, quiet: bool) -> Self {
+        let stdout = output.stdout.trim();
+
+        if quiet {
+            // In quiet mode, output is just the token
+            Self {
+                token: Some(stdout.to_string()),
+                join_command: None,
+                role,
+                output: stdout.to_string(),
+            }
+        } else {
+            // Normal mode: parse the join command
+            // Output format:
+            // To add a worker to this swarm, run the following command:
+            //
+            //     docker swarm join --token SWMTKN-... 192.168.1.1:2377
+
+            let mut token = None;
+            let mut join_command = None;
+
+            for line in stdout.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("docker swarm join") {
+                    join_command = Some(trimmed.to_string());
+
+                    // Extract token from the join command
+                    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                    for (i, part) in parts.iter().enumerate() {
+                        if *part == "--token" {
+                            if let Some(t) = parts.get(i + 1) {
+                                token = Some((*t).to_string());
+                            }
+                        }
+                    }
+                }
+            }
+
+            Self {
+                token,
+                join_command,
+                role,
+                output: stdout.to_string(),
+            }
+        }
+    }
+}
+
+/// Docker swarm join-token command builder
+///
+/// Retrieves or rotates the join token for a swarm.
+#[derive(Debug, Clone)]
+pub struct SwarmJoinTokenCommand {
+    /// The role (worker or manager)
+    role: SwarmNodeRole,
+    /// Only display the token (no join command)
+    quiet: bool,
+    /// Rotate the join token
+    rotate: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmJoinTokenCommand {
+    /// Create a new swarm join-token command for the specified role
+    #[must_use]
+    pub fn new(role: SwarmNodeRole) -> Self {
+        Self {
+            role,
+            quiet: false,
+            rotate: false,
+            executor: CommandExecutor::default(),
+        }
+    }
+
+    /// Create a command to get the worker join token
+    #[must_use]
+    pub fn worker() -> Self {
+        Self::new(SwarmNodeRole::Worker)
+    }
+
+    /// Create a command to get the manager join token
+    #[must_use]
+    pub fn manager() -> Self {
+        Self::new(SwarmNodeRole::Manager)
+    }
+
+    /// Only display the token (no join command)
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    /// Rotate the join token
+    #[must_use]
+    pub fn rotate(mut self) -> Self {
+        self.rotate = true;
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "join-token".to_string()];
+
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        if self.rotate {
+            args.push("--rotate".to_string());
+        }
+
+        args.push(self.role.as_str().to_string());
+
+        args
+    }
+}
+
+impl Default for SwarmJoinTokenCommand {
+    fn default() -> Self {
+        Self::worker()
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmJoinTokenCommand {
+    type Output = SwarmJoinTokenResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmJoinTokenResult::parse(&output, self.role, self.quiet))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_join_token_worker() {
+        let cmd = SwarmJoinTokenCommand::worker();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "join-token", "worker"]);
+    }
+
+    #[test]
+    fn test_join_token_manager() {
+        let cmd = SwarmJoinTokenCommand::manager();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "join-token", "manager"]);
+    }
+
+    #[test]
+    fn test_join_token_quiet() {
+        let cmd = SwarmJoinTokenCommand::worker().quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--quiet".to_string()));
+        assert!(args.contains(&"worker".to_string()));
+    }
+
+    #[test]
+    fn test_join_token_rotate() {
+        let cmd = SwarmJoinTokenCommand::manager().rotate();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--rotate".to_string()));
+        assert!(args.contains(&"manager".to_string()));
+    }
+
+    #[test]
+    fn test_join_token_all_options() {
+        let cmd = SwarmJoinTokenCommand::worker().quiet().rotate();
+        let args = cmd.build_args();
+        assert_eq!(
+            args,
+            vec!["swarm", "join-token", "--quiet", "--rotate", "worker"]
+        );
+    }
+
+    #[test]
+    fn test_node_role_display() {
+        assert_eq!(SwarmNodeRole::Worker.to_string(), "worker");
+        assert_eq!(SwarmNodeRole::Manager.to_string(), "manager");
+    }
+}

--- a/src/command/swarm/leave.rs
+++ b/src/command/swarm/leave.rs
@@ -1,0 +1,101 @@
+//! Docker swarm leave command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm leave command
+#[derive(Debug, Clone)]
+pub struct SwarmLeaveResult {
+    /// Whether the leave was successful
+    pub success: bool,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmLeaveResult {
+    /// Parse the swarm leave output
+    fn parse(output: &CommandOutput) -> Self {
+        Self {
+            success: output.success,
+            output: output.stdout.clone(),
+        }
+    }
+}
+
+/// Docker swarm leave command builder
+#[derive(Debug, Clone, Default)]
+pub struct SwarmLeaveCommand {
+    /// Force leave even if this is the last manager
+    force: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmLeaveCommand {
+    /// Create a new swarm leave command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Force leave even if this is the last manager or cluster will become unavailable
+    #[must_use]
+    pub fn force(mut self) -> Self {
+        self.force = true;
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "leave".to_string()];
+
+        if self.force {
+            args.push("--force".to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmLeaveCommand {
+    type Output = SwarmLeaveResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmLeaveResult::parse(&output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_leave_basic() {
+        let cmd = SwarmLeaveCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "leave"]);
+    }
+
+    #[test]
+    fn test_swarm_leave_force() {
+        let cmd = SwarmLeaveCommand::new().force();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--force".to_string()));
+    }
+}

--- a/src/command/swarm/mod.rs
+++ b/src/command/swarm/mod.rs
@@ -1,0 +1,22 @@
+//! Docker Swarm command implementations.
+//!
+//! This module provides commands for managing Docker Swarm clusters,
+//! including initialization, joining, and management operations.
+
+pub mod ca;
+pub mod init;
+pub mod join;
+pub mod join_token;
+pub mod leave;
+pub mod unlock;
+pub mod unlock_key;
+pub mod update;
+
+pub use ca::{SwarmCaCommand, SwarmCaResult};
+pub use init::{SwarmInitCommand, SwarmInitResult};
+pub use join::{SwarmJoinCommand, SwarmJoinResult};
+pub use join_token::{SwarmJoinTokenCommand, SwarmJoinTokenResult, SwarmNodeRole};
+pub use leave::{SwarmLeaveCommand, SwarmLeaveResult};
+pub use unlock::{SwarmUnlockCommand, SwarmUnlockResult};
+pub use unlock_key::{SwarmUnlockKeyCommand, SwarmUnlockKeyResult};
+pub use update::{SwarmUpdateCommand, SwarmUpdateResult};

--- a/src/command/swarm/unlock.rs
+++ b/src/command/swarm/unlock.rs
@@ -1,0 +1,76 @@
+//! Docker swarm unlock command implementation.
+
+use crate::command::{CommandExecutor, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm unlock command
+#[derive(Debug, Clone)]
+pub struct SwarmUnlockResult {
+    /// Whether the unlock was successful
+    pub success: bool,
+    /// Raw output from the command
+    pub output: String,
+}
+
+/// Docker swarm unlock command builder
+///
+/// Unlock a locked swarm manager node.
+#[derive(Debug, Clone, Default)]
+pub struct SwarmUnlockCommand {
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmUnlockCommand {
+    /// Create a new swarm unlock command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "unlock".to_string()];
+        args.extend(self.executor.raw_args.clone());
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmUnlockCommand {
+    type Output = SwarmUnlockResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmUnlockResult {
+            success: true,
+            output: output.stdout,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_unlock_basic() {
+        let cmd = SwarmUnlockCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "unlock"]);
+    }
+}

--- a/src/command/swarm/unlock_key.rs
+++ b/src/command/swarm/unlock_key.rs
@@ -1,0 +1,154 @@
+//! Docker swarm unlock-key command implementation.
+
+use crate::command::{CommandExecutor, CommandOutput, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm unlock-key command
+#[derive(Debug, Clone)]
+pub struct SwarmUnlockKeyResult {
+    /// The unlock key
+    pub key: Option<String>,
+    /// Raw output from the command
+    pub output: String,
+}
+
+impl SwarmUnlockKeyResult {
+    /// Parse the swarm unlock-key output
+    fn parse(output: &CommandOutput, quiet: bool) -> Self {
+        let stdout = output.stdout.trim();
+
+        let key = if quiet {
+            // In quiet mode, output is just the key
+            Some(stdout.to_string())
+        } else {
+            // Normal mode: parse the key from output
+            // Output format:
+            // To unlock a swarm manager after it restarts, run the `docker swarm unlock`
+            // command and provide the following key:
+            //
+            //     SWMKEY-1-...
+
+            let mut found_key = None;
+            for line in stdout.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("SWMKEY-") {
+                    found_key = Some(trimmed.to_string());
+                    break;
+                }
+            }
+            found_key
+        };
+
+        Self {
+            key,
+            output: stdout.to_string(),
+        }
+    }
+}
+
+/// Docker swarm unlock-key command builder
+///
+/// Manage the unlock key for a locked swarm.
+#[derive(Debug, Clone, Default)]
+pub struct SwarmUnlockKeyCommand {
+    /// Only display the key (no instructions)
+    quiet: bool,
+    /// Rotate the unlock key
+    rotate: bool,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmUnlockKeyCommand {
+    /// Create a new swarm unlock-key command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Only display the key (no instructions)
+    #[must_use]
+    pub fn quiet(mut self) -> Self {
+        self.quiet = true;
+        self
+    }
+
+    /// Rotate the unlock key
+    #[must_use]
+    pub fn rotate(mut self) -> Self {
+        self.rotate = true;
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "unlock-key".to_string()];
+
+        if self.quiet {
+            args.push("--quiet".to_string());
+        }
+
+        if self.rotate {
+            args.push("--rotate".to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmUnlockKeyCommand {
+    type Output = SwarmUnlockKeyResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmUnlockKeyResult::parse(&output, self.quiet))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_unlock_key_basic() {
+        let cmd = SwarmUnlockKeyCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "unlock-key"]);
+    }
+
+    #[test]
+    fn test_swarm_unlock_key_quiet() {
+        let cmd = SwarmUnlockKeyCommand::new().quiet();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--quiet".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_unlock_key_rotate() {
+        let cmd = SwarmUnlockKeyCommand::new().rotate();
+        let args = cmd.build_args();
+        assert!(args.contains(&"--rotate".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_unlock_key_all_options() {
+        let cmd = SwarmUnlockKeyCommand::new().quiet().rotate();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "unlock-key", "--quiet", "--rotate"]);
+    }
+}

--- a/src/command/swarm/update.rs
+++ b/src/command/swarm/update.rs
@@ -1,0 +1,219 @@
+//! Docker swarm update command implementation.
+
+use crate::command::{CommandExecutor, DockerCommand};
+use crate::error::Result;
+use async_trait::async_trait;
+
+/// Result of swarm update command
+#[derive(Debug, Clone)]
+pub struct SwarmUpdateResult {
+    /// Whether the update was successful
+    pub success: bool,
+    /// Raw output from the command
+    pub output: String,
+}
+
+/// Docker swarm update command builder
+///
+/// Update swarm configuration.
+#[derive(Debug, Clone, Default)]
+pub struct SwarmUpdateCommand {
+    /// Enable or disable autolock
+    autolock: Option<bool>,
+    /// Validity period for node certificates (ns|us|ms|s|m|h)
+    cert_expiry: Option<String>,
+    /// Dispatcher heartbeat period (ns|us|ms|s|m|h)
+    dispatcher_heartbeat: Option<String>,
+    /// Specifications of external CA to use
+    external_ca: Option<String>,
+    /// Number of snapshots to keep beyond current snapshot
+    max_snapshots: Option<u32>,
+    /// Number of log entries to trigger a snapshot
+    snapshot_interval: Option<u32>,
+    /// Task history retention limit
+    task_history_limit: Option<i32>,
+    /// Command executor
+    pub executor: CommandExecutor,
+}
+
+impl SwarmUpdateCommand {
+    /// Create a new swarm update command
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable autolock
+    #[must_use]
+    pub fn autolock(mut self, enabled: bool) -> Self {
+        self.autolock = Some(enabled);
+        self
+    }
+
+    /// Set the certificate expiry duration
+    #[must_use]
+    pub fn cert_expiry(mut self, expiry: impl Into<String>) -> Self {
+        self.cert_expiry = Some(expiry.into());
+        self
+    }
+
+    /// Set the dispatcher heartbeat period
+    #[must_use]
+    pub fn dispatcher_heartbeat(mut self, heartbeat: impl Into<String>) -> Self {
+        self.dispatcher_heartbeat = Some(heartbeat.into());
+        self
+    }
+
+    /// Set external CA specifications
+    #[must_use]
+    pub fn external_ca(mut self, spec: impl Into<String>) -> Self {
+        self.external_ca = Some(spec.into());
+        self
+    }
+
+    /// Set the maximum number of snapshots to keep
+    #[must_use]
+    pub fn max_snapshots(mut self, count: u32) -> Self {
+        self.max_snapshots = Some(count);
+        self
+    }
+
+    /// Set the snapshot interval
+    #[must_use]
+    pub fn snapshot_interval(mut self, interval: u32) -> Self {
+        self.snapshot_interval = Some(interval);
+        self
+    }
+
+    /// Set the task history retention limit
+    #[must_use]
+    pub fn task_history_limit(mut self, limit: i32) -> Self {
+        self.task_history_limit = Some(limit);
+        self
+    }
+
+    /// Build the command arguments
+    fn build_args(&self) -> Vec<String> {
+        let mut args = vec!["swarm".to_string(), "update".to_string()];
+
+        if let Some(enabled) = self.autolock {
+            args.push("--autolock".to_string());
+            args.push(enabled.to_string());
+        }
+
+        if let Some(ref expiry) = self.cert_expiry {
+            args.push("--cert-expiry".to_string());
+            args.push(expiry.clone());
+        }
+
+        if let Some(ref heartbeat) = self.dispatcher_heartbeat {
+            args.push("--dispatcher-heartbeat".to_string());
+            args.push(heartbeat.clone());
+        }
+
+        if let Some(ref spec) = self.external_ca {
+            args.push("--external-ca".to_string());
+            args.push(spec.clone());
+        }
+
+        if let Some(count) = self.max_snapshots {
+            args.push("--max-snapshots".to_string());
+            args.push(count.to_string());
+        }
+
+        if let Some(interval) = self.snapshot_interval {
+            args.push("--snapshot-interval".to_string());
+            args.push(interval.to_string());
+        }
+
+        if let Some(limit) = self.task_history_limit {
+            args.push("--task-history-limit".to_string());
+            args.push(limit.to_string());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl DockerCommand for SwarmUpdateCommand {
+    type Output = SwarmUpdateResult;
+
+    fn get_executor(&self) -> &CommandExecutor {
+        &self.executor
+    }
+
+    fn get_executor_mut(&mut self) -> &mut CommandExecutor {
+        &mut self.executor
+    }
+
+    fn build_command_args(&self) -> Vec<String> {
+        self.build_args()
+    }
+
+    async fn execute(&self) -> Result<Self::Output> {
+        let args = self.build_args();
+        let output = self.execute_command(args).await?;
+        Ok(SwarmUpdateResult {
+            success: true,
+            output: output.stdout,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swarm_update_basic() {
+        let cmd = SwarmUpdateCommand::new();
+        let args = cmd.build_args();
+        assert_eq!(args, vec!["swarm", "update"]);
+    }
+
+    #[test]
+    fn test_swarm_update_autolock_enable() {
+        let cmd = SwarmUpdateCommand::new().autolock(true);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--autolock".to_string()));
+        assert!(args.contains(&"true".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_update_autolock_disable() {
+        let cmd = SwarmUpdateCommand::new().autolock(false);
+        let args = cmd.build_args();
+        assert!(args.contains(&"--autolock".to_string()));
+        assert!(args.contains(&"false".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_update_cert_expiry() {
+        let cmd = SwarmUpdateCommand::new().cert_expiry("90d");
+        let args = cmd.build_args();
+        assert!(args.contains(&"--cert-expiry".to_string()));
+        assert!(args.contains(&"90d".to_string()));
+    }
+
+    #[test]
+    fn test_swarm_update_all_options() {
+        let cmd = SwarmUpdateCommand::new()
+            .autolock(true)
+            .cert_expiry("90d")
+            .dispatcher_heartbeat("5s")
+            .external_ca("protocol=cfssl,url=https://ca.example.com")
+            .max_snapshots(5)
+            .snapshot_interval(10000)
+            .task_history_limit(10);
+
+        let args = cmd.build_args();
+        assert!(args.contains(&"--autolock".to_string()));
+        assert!(args.contains(&"--cert-expiry".to_string()));
+        assert!(args.contains(&"--dispatcher-heartbeat".to_string()));
+        assert!(args.contains(&"--external-ca".to_string()));
+        assert!(args.contains(&"--max-snapshots".to_string()));
+        assert!(args.contains(&"--snapshot-interval".to_string()));
+        assert!(args.contains(&"--task-history-limit".to_string()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,12 @@ pub use command::{
     start::{StartCommand, StartResult},
     stats::{ContainerStats, StatsCommand, StatsResult},
     stop::{StopCommand, StopResult},
+    swarm::{
+        SwarmCaCommand, SwarmCaResult, SwarmInitCommand, SwarmInitResult, SwarmJoinCommand,
+        SwarmJoinResult, SwarmJoinTokenCommand, SwarmJoinTokenResult, SwarmLeaveCommand,
+        SwarmLeaveResult, SwarmNodeRole, SwarmUnlockCommand, SwarmUnlockKeyCommand,
+        SwarmUnlockKeyResult, SwarmUnlockResult, SwarmUpdateCommand, SwarmUpdateResult,
+    },
     system::{
         BuildCacheInfo, BuildCacheUsage, ContainerInfo as SystemContainerInfo, ContainerUsage,
         DiskUsage, ImageInfo as SystemImageInfo, ImageUsage, PruneResult, SystemDfCommand,


### PR DESCRIPTION
Implements all Docker Swarm management commands to address #84.

## New Commands

- **`swarm init`**: Initialize a new swarm with full option support (advertise-addr, autolock, availability, cert-expiry, data-path-addr, dispatcher-heartbeat, external-ca, force-new-cluster, listen-addr, etc.)
- **`swarm join`**: Join a swarm as a worker or manager node
- **`swarm leave`**: Leave the swarm (with force option)
- **`swarm join-token`**: Retrieve or rotate join tokens for workers/managers
- **`swarm ca`**: Display and rotate the root CA certificate
- **`swarm unlock`**: Unlock a locked manager node
- **`swarm unlock-key`**: Retrieve or rotate the unlock key
- **`swarm update`**: Update swarm configuration (autolock, cert-expiry, dispatcher-heartbeat, etc.)

## Implementation Details

Each command follows the existing builder pattern with:
- Fluent method chaining for all options
- Typed result structs with parsed output
- Full unit test coverage
- Doc comments for all public APIs

## Example Usage

```rust
use docker_wrapper::{DockerCommand, SwarmInitCommand, SwarmJoinTokenCommand, SwarmNodeRole};

// Initialize a new swarm
let result = SwarmInitCommand::new()
    .advertise_addr("192.168.1.1:2377")
    .autolock()
    .execute()
    .await?;

// Get worker join token
let token = SwarmJoinTokenCommand::worker()
    .quiet()
    .execute()
    .await?;
```

Closes #84