### PR TITLE
fix: handle IMAGE header in docker images output

### DIFF
--- a/src/command/images.rs
+++ b/src/command/images.rs
@@ -507,8 +507,8 @@ impl ImagesCommand {
             return images;
         }
 
-        // Skip header line if present
-        let data_lines = if lines[0].starts_with("REPOSITORY") {
+        // Skip header line if present (handle both old "REPOSITORY" and new "IMAGE" formats)
+        let data_lines = if lines[0].starts_with("REPOSITORY") || lines[0].starts_with("IMAGE") {
             &lines[1..]
         } else {
             &lines[..]


### PR DESCRIPTION
Docker Desktop now uses IMAGE instead of REPOSITORY as the header column name in docker images output. Update parse_table_output to skip both header formats.

This fixes a test failure where the header row was being parsed as an image entry.