### PR TITLE
ci: add examples compilation check to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Build
         run: cargo build --all-features
 
+      - name: Build examples
+        run: cargo build --examples --all-features
+
       - name: Run tests
         run: cargo test --lib --all-features && cargo test --doc --all-features
 
@@ -109,8 +112,8 @@ jobs:
         env:
           DOCKER_HOST: unix:///var/run/docker.sock
 
-      - name: Test examples
-        run: cargo check --examples --all-features
+      - name: Build examples
+        run: cargo build --examples --all-features
 
   security:
     name: Security Audit

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -12,7 +12,7 @@ jobs:
   quick-tests:
     name: Quick Tests
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -37,6 +37,9 @@ jobs:
       - name: Fast check
         run: cargo check --all-features
 
+      - name: Check examples compile
+        run: cargo check --examples --all-features
+
       - name: Run unit tests only
         run: cargo test --lib --all-features
 
@@ -44,7 +47,7 @@ jobs:
     name: Fast Build Check
     runs-on: ubuntu-latest
     needs: quick-tests
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Ensures examples are always compiled as part of CI to catch breaking changes early.

## Changes

- Add 'Build examples' step to main CI workflow test job (runs on all platforms)
- Upgrade 'Test examples' to 'Build examples' in docker-tests job (uses `build` instead of `check`)
- Add 'Check examples compile' step to quick-check workflow for fast PR feedback

This provides coverage at multiple levels:
- Quick check: fast `cargo check` for immediate feedback on PRs
- Main CI: full `cargo build` across all platforms (Ubuntu, macOS, Windows)
- Docker tests: full `cargo build` alongside integration tests