### PR TITLE
fix: use SIGKILL and StopCommand in lifecycle example

### DIFF
--- a/examples/lifecycle_commands.rs
+++ b/examples/lifecycle_commands.rs
@@ -1,7 +1,7 @@
 //! Example demonstrating container lifecycle commands including rm, kill, and logs
 
 use docker_wrapper::command::DockerCommand;
-use docker_wrapper::{KillCommand, LogsCommand, RmCommand, RunCommand};
+use docker_wrapper::{KillCommand, LogsCommand, RmCommand, RunCommand, StopCommand};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -42,18 +42,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     println!("Recent logs:\n{}", logs.stdout);
 
-    // Send SIGTERM to the container
-    println!("\nSending SIGTERM to container...");
+    // Send SIGKILL to the container (demonstrates kill command)
+    println!("\nSending SIGKILL to container...");
     let _kill_result = KillCommand::new(container_name)
-        .signal("SIGTERM")
+        .signal("SIGKILL")
         .run()
         .await?;
-    println!("Container killed with SIGTERM signal");
-
-    // Wait a moment for the container to stop
-    sleep(Duration::from_secs(1)).await;
+    println!("Container killed with SIGKILL signal");
 
     // Remove the container
+    println!("\nRemoving container...");
+    let _rm_result = RmCommand::new(container_name).run().await?;
+    println!("Container removed successfully");
+
+    // Demonstrate the proper stop -> rm pattern
+    println!("\n--- Demonstrating stop -> rm pattern ---\n");
+
+    // Start another container
+    println!("Starting another container...");
+    let run_result = RunCommand::new("alpine:latest")
+        .name(container_name)
+        .detach()
+        .cmd(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            "while true; do echo 'Running...'; sleep 1; done".to_string(),
+        ])
+        .execute()
+        .await?;
+    println!("Container started with ID: {}", run_result.0);
+
+    sleep(Duration::from_secs(2)).await;
+
+    // Stop the container gracefully (sends SIGTERM, waits, then SIGKILL)
+    println!("\nStopping container gracefully...");
+    let stop_result = StopCommand::new(container_name)
+        .timeout(5)
+        .execute()
+        .await?;
+    println!("Container stopped: {:?}", stop_result.stopped_containers);
+
+    // Now remove it (no force needed since it's stopped)
     println!("\nRemoving container...");
     let _rm_result = RmCommand::new(container_name).run().await?;
     println!("Container removed successfully");


### PR DESCRIPTION
## Summary

Fixes the `lifecycle_commands` example which was failing on Windows (and potentially other systems) because:
1. `KillCommand` with SIGTERM doesn't guarantee immediate container termination
2. The 1 second sleep wasn't enough for the container to fully stop
3. `RmCommand` without `--force` fails on running containers

## Changes

- Use SIGKILL instead of SIGTERM for the kill demo (immediate termination)
- Added a second section demonstrating the proper `stop` -> `rm` pattern
- Print the stopped container names from `StopResult` instead of discarding the result

## Testing

Verified the example runs successfully:
```
cargo run --example lifecycle_commands
```

Fixes #201