### PR TITLE
docs: update version examples to 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A type-safe Docker CLI wrapper for Rust.
 
 ```toml
 [dependencies]
-docker-wrapper = "0.9"
+docker-wrapper = "0.10"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -48,10 +48,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ```toml
 # Docker Compose support
-docker-wrapper = { version = "0.9", features = ["compose"] }
+docker-wrapper = { version = "0.10", features = ["compose"] }
 
 # Container templates (Redis, PostgreSQL, etc.)
-docker-wrapper = { version = "0.9", features = ["templates"] }
+docker-wrapper = { version = "0.10", features = ["templates"] }
 ```
 
 ### Compose Example

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -19,10 +19,10 @@ Add template features to your `Cargo.toml`:
 ```toml
 [dependencies]
 # All templates
-docker-wrapper = { version = "0.9", features = ["templates"] }
+docker-wrapper = { version = "0.10", features = ["templates"] }
 
 # Or individual templates
-docker-wrapper = { version = "0.9", features = ["template-redis", "template-postgres"] }
+docker-wrapper = { version = "0.10", features = ["template-redis", "template-postgres"] }
 ```
 
 Basic usage:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@
 //! ## `compose` - Docker Compose Support
 //!
 //! ```toml
-//! docker-wrapper = { version = "0.9", features = ["compose"] }
+//! docker-wrapper = { version = "0.10", features = ["compose"] }
 //! ```
 //!
 //! ```rust,no_run
@@ -207,7 +207,7 @@
 //! ## `templates` - Pre-configured Containers
 //!
 //! ```toml
-//! docker-wrapper = { version = "0.9", features = ["templates"] }
+//! docker-wrapper = { version = "0.10", features = ["templates"] }
 //! ```
 //!
 //! Templates provide ready-to-use configurations for common services:
@@ -238,13 +238,13 @@
 //! ## `swarm` - Docker Swarm Commands
 //!
 //! ```toml
-//! docker-wrapper = { version = "0.9", features = ["swarm"] }
+//! docker-wrapper = { version = "0.10", features = ["swarm"] }
 //! ```
 //!
 //! ## `manifest` - Multi-arch Manifest Commands
 //!
 //! ```toml
-//! docker-wrapper = { version = "0.9", features = ["manifest"] }
+//! docker-wrapper = { version = "0.10", features = ["manifest"] }
 //! ```
 //!
 //! # Tracing and Debugging


### PR DESCRIPTION
Updates all version examples in documentation from 0.9 to 0.10 to match the new release.

Files updated:
- README.md
- src/lib.rs (rustdoc examples)
- docs/TEMPLATES.md