### PR TITLE
feat: add connection_string() passthrough to ContainerGuard

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -595,6 +595,21 @@ impl Template for CustomTemplate {
     }
 }
 
+/// Trait for templates that can provide a connection string.
+///
+/// This trait is implemented by templates that represent services with
+/// connection endpoints (databases, caches, etc.).
+pub trait HasConnectionString {
+    /// Returns the connection string/URL for connecting to the service.
+    ///
+    /// The format depends on the service type:
+    /// - Redis: `redis://[password@]host:port`
+    /// - PostgreSQL: `postgresql://user:password@host:port/database`
+    /// - MySQL: `mysql://user:password@host:port/database`
+    /// - MongoDB: `mongodb://[user:password@]host:port[/database]`
+    fn connection_string(&self) -> String;
+}
+
 // Compatibility re-exports for backward compatibility
 // These allow users to still import directly from template::
 #[cfg(feature = "template-redis")]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use crate::command::DockerCommand;
-use crate::template::{Template, TemplateError};
+use crate::template::{HasConnectionString, Template, TemplateError};
 use crate::{
     LogsCommand, NetworkCreateCommand, NetworkRmCommand, PortCommand, RmCommand, StopCommand,
 };
@@ -513,6 +513,38 @@ impl<T: Template> ContainerGuard<T> {
             let _ = self.template.remove().await;
         }
         Ok(())
+    }
+}
+
+impl<T: Template + HasConnectionString> ContainerGuard<T> {
+    /// Get the connection string for the underlying service.
+    ///
+    /// This is a convenience method that delegates to the template's
+    /// `connection_string()` implementation. The format depends on the
+    /// service type (e.g., `redis://host:port` for Redis).
+    ///
+    /// This method is only available for templates that implement
+    /// [`HasConnectionString`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use docker_wrapper::testing::ContainerGuard;
+    /// # use docker_wrapper::RedisTemplate;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let guard = ContainerGuard::new(RedisTemplate::new("redis").port(6379))
+    ///     .start()
+    ///     .await?;
+    ///
+    /// // Direct access to connection string
+    /// let conn = guard.connection_string();
+    /// // Instead of: guard.template().connection_string()
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn connection_string(&self) -> String {
+        self.template.connection_string()
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a convenient way to access the connection string directly from ContainerGuard without going through `.template()`.

Closes #222

## Changes

- Add `HasConnectionString` trait in template module
- Implement `HasConnectionString` for `RedisTemplate`
- Add `connection_string()` method on `ContainerGuard<T>` where `T: HasConnectionString`

## Current vs New API

**Before:**
```rust
let guard = ContainerGuard::new(RedisTemplate::new("redis").port(6379))
    .start()
    .await?;
let conn = guard.template().connection_string();
```

**After:**
```rust
let guard = ContainerGuard::new(RedisTemplate::new("redis").port(6379))
    .start()
    .await?;
let conn = guard.connection_string();  // redis://localhost:6379
```

## Design

The `connection_string()` method is only available for templates that implement `HasConnectionString`. This is enforced at compile time via trait bounds:

```rust
impl<T: Template + HasConnectionString> ContainerGuard<T> {
    pub fn connection_string(&self) -> String { ... }
}
```

Currently implemented for:
- `RedisTemplate` - returns `redis://[:password@]host:port`

Other templates can implement `HasConnectionString` in the future.

## Tests

- 3 new unit tests for `RedisTemplate::connection_string()`
- 2 new integration tests for `ContainerGuard::connection_string()`