### PR TITLE
fix: resolve clippy lints from Rust 1.95

### DIFF
--- a/src/template/database/mysql.rs
+++ b/src/template/database/mysql.rs
@@ -316,7 +316,7 @@ impl Template for MysqlTemplate {
         // Custom MySQL readiness check - increased timeout for charset/collation configs
         // MySQL 8.0 can take 90+ seconds to initialize on slower CI systems
         let wait_timeout = Duration::from_secs(120);
-        let check_interval = Duration::from_millis(1000);
+        let check_interval = Duration::from_secs(1);
 
         timeout(wait_timeout, async {
             let mut consecutive_successes = 0;

--- a/src/template/redis/cluster.rs
+++ b/src/template/redis/cluster.rs
@@ -447,8 +447,7 @@ impl RedisClusterTemplate {
     pub async fn is_ready(&self) -> bool {
         self.cluster_info()
             .await
-            .map(|info| info.cluster_state == "ok")
-            .unwrap_or(false)
+            .is_ok_and(|info| info.cluster_state == "ok")
     }
 
     /// Wait for the cluster to become ready, with a timeout.


### PR DESCRIPTION
Rust 1.95 on CI runners introduced two new clippy lints that fail every PR with `-D warnings`:

- `clippy::map_unwrap_or` in `src/template/redis/cluster.rs` -- replaced `.map(...).unwrap_or(false)` with `.is_ok_and(...)`
- `clippy::duration_suboptimal_units` in `src/template/database/mysql.rs` -- replaced `Duration::from_millis(1000)` with `Duration::from_secs(1)`

No behavior change. Unblocks CI for all open PRs.