### PR TITLE
feat: add version pinning for Redis Stack and RedisInsight images

### DIFF
--- a/src/template/redis/basic.rs
+++ b/src/template/redis/basic.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 pub struct RedisTemplate {
     config: TemplateConfig,
     use_redis_stack: bool,
+    stack_tag: String,
 }
 
 impl RedisTemplate {
@@ -45,6 +46,7 @@ impl RedisTemplate {
         Self {
             config,
             use_redis_stack: false,
+            stack_tag: REDIS_STACK_TAG.to_string(),
         }
     }
 
@@ -115,10 +117,40 @@ impl RedisTemplate {
         self
     }
 
-    /// Use Redis Stack image instead of basic Redis
+    /// Use Redis Stack image instead of basic Redis.
+    ///
+    /// Uses the `redis/redis-stack` image pinned to a known-good default tag
+    /// (`7.4.0-v3`) rather than `latest`, so that runs are reproducible. Call
+    /// [`stack_version`](Self::stack_version) to pin a different tag.
     pub fn with_redis_stack(mut self) -> Self {
         self.use_redis_stack = true;
         self
+    }
+
+    /// Pin the Redis Stack image tag (e.g. `"7.4.0-v3"`).
+    ///
+    /// Only affects the image used when [`Self::with_redis_stack`] is enabled.
+    /// The default is a known-good pinned tag rather than `latest`, so that runs
+    /// are reproducible. For full control over both the image name and tag, use
+    /// [`Self::custom_image`] instead.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::template::RedisTemplate;
+    ///
+    /// let template = RedisTemplate::new("my-redis")
+    ///     .with_redis_stack()
+    ///     .stack_version("7.4.0-v3");
+    /// ```
+    pub fn stack_version(mut self, tag: impl Into<String>) -> Self {
+        self.stack_tag = tag.into();
+        self
+    }
+
+    /// Build the image reference used when Redis Stack is enabled.
+    fn stack_image(&self) -> String {
+        format!("{REDIS_STACK_IMAGE}:{}", self.stack_tag)
     }
 
     /// Use a custom image and tag
@@ -204,7 +236,7 @@ impl Template for RedisTemplate {
 
         // Choose image based on Redis Stack preference
         let image_tag = if self.use_redis_stack {
-            format!("{REDIS_STACK_IMAGE}:{REDIS_STACK_TAG}")
+            self.stack_image()
         } else {
             format!("{}:{}", config.image, config.tag)
         };
@@ -368,6 +400,47 @@ mod tests {
         assert!(args.contains(&"test-redis".to_string()));
         assert!(args.contains(&"--publish".to_string()));
         assert!(args.contains(&"16379:6379".to_string()));
+    }
+
+    #[test]
+    fn test_redis_stack_default_pinned_tag() {
+        // Redis Stack defaults to a pinned, known-good tag (not latest) for
+        // reproducible runs.
+        let template = RedisTemplate::new("test-redis").with_redis_stack();
+
+        assert_eq!(
+            template.stack_image(),
+            format!("{REDIS_STACK_IMAGE}:7.4.0-v3")
+        );
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"redis/redis-stack:7.4.0-v3".to_string()));
+        assert!(!args.iter().any(|a| a == "redis/redis-stack:latest"));
+    }
+
+    #[test]
+    fn test_redis_stack_version_override() {
+        let template = RedisTemplate::new("test-redis")
+            .with_redis_stack()
+            .stack_version("7.2.0-v9");
+
+        assert_eq!(template.stack_image(), "redis/redis-stack:7.2.0-v9");
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"redis/redis-stack:7.2.0-v9".to_string()));
+    }
+
+    #[test]
+    fn test_redis_stack_version_ignored_without_stack() {
+        // stack_version only affects the image when Redis Stack is enabled.
+        let template = RedisTemplate::new("test-redis").stack_version("7.2.0-v9");
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+        assert!(args.contains(&"redis:7-alpine".to_string()));
+        assert!(!args.iter().any(|a| a.starts_with("redis/redis-stack")));
     }
 
     #[test]

--- a/src/template/redis/cluster.rs
+++ b/src/template/redis/cluster.rs
@@ -7,6 +7,9 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::missing_errors_doc)]
 
+use super::common::{
+    REDIS_INSIGHT_CLUSTER_IMAGE, REDIS_INSIGHT_TAG, REDIS_STACK_SERVER_IMAGE, REDIS_STACK_TAG,
+};
 use crate::template::{Template, TemplateConfig, TemplateError};
 use crate::{DockerCommand, ExecCommand, NetworkCreateCommand, RunCommand};
 use async_trait::async_trait;
@@ -37,10 +40,14 @@ pub struct RedisClusterTemplate {
     auto_remove: bool,
     /// Whether to use Redis Stack instead of standard Redis
     use_redis_stack: bool,
+    /// Image tag used for the Redis Stack server image
+    stack_tag: String,
     /// Whether to include RedisInsight GUI
     with_redis_insight: bool,
     /// Port for RedisInsight UI
     redis_insight_port: u16,
+    /// Image tag used for the RedisInsight image
+    redis_insight_tag: String,
     /// Custom Redis image
     redis_image: Option<String>,
     /// Custom Redis tag
@@ -68,8 +75,10 @@ impl RedisClusterTemplate {
             node_timeout: 5000,
             auto_remove: false,
             use_redis_stack: false,
+            stack_tag: REDIS_STACK_TAG.to_string(),
             with_redis_insight: false,
             redis_insight_port: 8001,
+            redis_insight_tag: REDIS_INSIGHT_TAG.to_string(),
             redis_image: None,
             redis_tag: None,
             platform: None,
@@ -192,13 +201,43 @@ impl RedisClusterTemplate {
         self
     }
 
-    /// Use Redis Stack instead of standard Redis (includes modules like JSON, Search, Graph, TimeSeries, Bloom)
+    /// Use Redis Stack instead of standard Redis (includes modules like JSON, Search, Graph, TimeSeries, Bloom).
+    ///
+    /// Uses the `redis/redis-stack-server` image pinned to a known-good default
+    /// tag (`7.4.0-v3`) rather than `latest`, so that runs are reproducible.
+    /// Call [`Self::stack_version`] to pin a different tag, or
+    /// [`Self::custom_redis_image`] for full control.
     pub fn with_redis_stack(mut self) -> Self {
         self.use_redis_stack = true;
         self
     }
 
-    /// Enable RedisInsight GUI for cluster visualization and management
+    /// Pin the Redis Stack server image tag (e.g. `"7.4.0-v3"`).
+    ///
+    /// Only affects the image used when [`Self::with_redis_stack`] is enabled.
+    /// The default is a known-good pinned tag rather than `latest`, so that runs
+    /// are reproducible. A [`Self::custom_redis_image`] takes precedence over
+    /// this setting.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::RedisClusterTemplate;
+    ///
+    /// let template = RedisClusterTemplate::new("my-cluster")
+    ///     .with_redis_stack()
+    ///     .stack_version("7.4.0-v3");
+    /// ```
+    pub fn stack_version(mut self, tag: impl Into<String>) -> Self {
+        self.stack_tag = tag.into();
+        self
+    }
+
+    /// Enable RedisInsight GUI for cluster visualization and management.
+    ///
+    /// Uses the `redislabs/redisinsight` image pinned to a known-good default
+    /// tag (`2.60`) rather than `latest`, so that runs are reproducible. Call
+    /// [`Self::redis_insight_version`] to pin a different tag.
     pub fn with_redis_insight(mut self) -> Self {
         self.with_redis_insight = true;
         self
@@ -207,6 +246,26 @@ impl RedisClusterTemplate {
     /// Set the port for RedisInsight UI (default: 8001)
     pub fn redis_insight_port(mut self, port: u16) -> Self {
         self.redis_insight_port = port;
+        self
+    }
+
+    /// Pin the RedisInsight image tag (e.g. `"2.60"`).
+    ///
+    /// Only affects the image used when [`Self::with_redis_insight`] is enabled.
+    /// The default is a known-good pinned tag rather than `latest`, so that runs
+    /// are reproducible.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::RedisClusterTemplate;
+    ///
+    /// let template = RedisClusterTemplate::new("my-cluster")
+    ///     .with_redis_insight()
+    ///     .redis_insight_version("2.60");
+    /// ```
+    pub fn redis_insight_version(mut self, tag: impl Into<String>) -> Self {
+        self.redis_insight_tag = tag.into();
         self
     }
 
@@ -246,17 +305,7 @@ impl RedisClusterTemplate {
         let cluster_port = port + 10000;
 
         // Choose image based on custom image or Redis Stack preference
-        let image = if let Some(ref custom_image) = self.redis_image {
-            if let Some(ref tag) = self.redis_tag {
-                format!("{}:{}", custom_image, tag)
-            } else {
-                custom_image.clone()
-            }
-        } else if self.use_redis_stack {
-            "redis/redis-stack-server:latest".to_string()
-        } else {
-            "redis:7-alpine".to_string()
-        };
+        let image = self.node_image();
 
         let mut cmd = RunCommand::new(image)
             .name(&node_name)
@@ -329,7 +378,7 @@ impl RedisClusterTemplate {
     async fn start_redis_insight(&self) -> Result<String, TemplateError> {
         let insight_name = format!("{}-insight", self.name);
 
-        let mut cmd = RunCommand::new("redislabs/redisinsight:latest")
+        let mut cmd = RunCommand::new(self.insight_image())
             .name(&insight_name)
             .network(&self.network_name)
             .port(self.redis_insight_port, 8001)
@@ -351,6 +400,35 @@ impl RedisClusterTemplate {
 
         let output = cmd.execute().await?;
         Ok(output.0)
+    }
+
+    /// Resolve the image reference used for each Redis node.
+    ///
+    /// A custom image (via [`custom_redis_image`](Self::custom_redis_image))
+    /// takes precedence; otherwise Redis Stack uses the pinned
+    /// `redis/redis-stack-server` tag and the default is `redis:7-alpine`.
+    fn node_image(&self) -> String {
+        if let Some(ref custom_image) = self.redis_image {
+            if let Some(ref tag) = self.redis_tag {
+                format!("{}:{}", custom_image, tag)
+            } else {
+                custom_image.clone()
+            }
+        } else if self.use_redis_stack {
+            self.stack_image()
+        } else {
+            "redis:7-alpine".to_string()
+        }
+    }
+
+    /// Build the Redis Stack server image reference (pinned tag by default).
+    fn stack_image(&self) -> String {
+        format!("{}:{}", REDIS_STACK_SERVER_IMAGE, self.stack_tag)
+    }
+
+    /// Build the RedisInsight image reference (pinned tag by default).
+    fn insight_image(&self) -> String {
+        format!("{}:{}", REDIS_INSIGHT_CLUSTER_IMAGE, self.redis_insight_tag)
     }
 
     /// Build the redis-cli ping arguments used for node readiness checks
@@ -930,6 +1008,57 @@ mod tests {
         assert!(template.use_redis_stack);
         assert!(template.with_redis_insight);
         assert_eq!(template.redis_insight_port, 8080);
+    }
+
+    #[test]
+    fn test_redis_cluster_stack_image_default_pinned() {
+        // Redis Stack defaults to a pinned, known-good tag (not latest).
+        let template = RedisClusterTemplate::new("test-cluster").with_redis_stack();
+
+        assert_eq!(template.stack_image(), "redis/redis-stack-server:7.4.0-v3");
+        assert_eq!(template.node_image(), "redis/redis-stack-server:7.4.0-v3");
+        assert_ne!(template.stack_image(), "redis/redis-stack-server:latest");
+    }
+
+    #[test]
+    fn test_redis_cluster_stack_version_override() {
+        let template = RedisClusterTemplate::new("test-cluster")
+            .with_redis_stack()
+            .stack_version("7.2.0-v9");
+
+        assert_eq!(template.stack_image(), "redis/redis-stack-server:7.2.0-v9");
+        assert_eq!(template.node_image(), "redis/redis-stack-server:7.2.0-v9");
+    }
+
+    #[test]
+    fn test_redis_cluster_node_image_default_and_custom() {
+        // Default (no stack, no custom) is the pinned alpine image.
+        let default_template = RedisClusterTemplate::new("test-cluster");
+        assert_eq!(default_template.node_image(), "redis:7-alpine");
+
+        // A custom image takes precedence over the stack preference.
+        let custom_template = RedisClusterTemplate::new("test-cluster")
+            .with_redis_stack()
+            .custom_redis_image("myrepo/redis", "1.2.3");
+        assert_eq!(custom_template.node_image(), "myrepo/redis:1.2.3");
+    }
+
+    #[test]
+    fn test_redis_cluster_insight_image_default_pinned() {
+        // RedisInsight defaults to a pinned, known-good tag (not latest).
+        let template = RedisClusterTemplate::new("test-cluster").with_redis_insight();
+
+        assert_eq!(template.insight_image(), "redislabs/redisinsight:2.60");
+        assert_ne!(template.insight_image(), "redislabs/redisinsight:latest");
+    }
+
+    #[test]
+    fn test_redis_cluster_insight_version_override() {
+        let template = RedisClusterTemplate::new("test-cluster")
+            .with_redis_insight()
+            .redis_insight_version("2.58");
+
+        assert_eq!(template.insight_image(), "redislabs/redisinsight:2.58");
     }
 
     #[test]

--- a/src/template/redis/common.rs
+++ b/src/template/redis/common.rs
@@ -12,17 +12,36 @@ pub const DEFAULT_REDIS_IMAGE: &str = "redis";
 /// Default Redis Alpine image tag
 pub const DEFAULT_REDIS_TAG: &str = "7-alpine";
 
-/// Redis Stack image
+/// Redis Stack image (full image, includes RedisInsight)
 pub const REDIS_STACK_IMAGE: &str = "redis/redis-stack";
 
-/// Redis Stack image tag
-pub const REDIS_STACK_TAG: &str = "latest";
+/// Redis Stack server image (server only, no RedisInsight)
+pub const REDIS_STACK_SERVER_IMAGE: &str = "redis/redis-stack-server";
 
-/// RedisInsight image
+/// Default Redis Stack image tag.
+///
+/// Pinned to a known-good release rather than `latest` so that runs are
+/// reproducible -- the image under test does not silently change when
+/// upstream publishes a new `latest`. Override with `stack_version()` or
+/// `custom_image()` to use a different tag.
+pub const REDIS_STACK_TAG: &str = "7.4.0-v3";
+
+/// RedisInsight image (as used by the standalone insight template)
 pub const REDIS_INSIGHT_IMAGE: &str = "redis/redisinsight";
 
-/// RedisInsight image tag
-pub const REDIS_INSIGHT_TAG: &str = "latest";
+/// RedisInsight image as used by the cluster template.
+///
+/// The cluster template historically pulls RedisInsight from the
+/// `redislabs/` organization, which is kept here for backwards
+/// compatibility. New standalone usage should prefer [`REDIS_INSIGHT_IMAGE`].
+pub const REDIS_INSIGHT_CLUSTER_IMAGE: &str = "redislabs/redisinsight";
+
+/// Default RedisInsight image tag.
+///
+/// Pinned to a known-good release rather than `latest` for reproducibility.
+/// Override with `redis_insight_version()` or `custom_image()` to use a
+/// different tag.
+pub const REDIS_INSIGHT_TAG: &str = "2.60";
 
 /// Default RedisInsight port
 pub const DEFAULT_REDIS_INSIGHT_PORT: u16 = 5540;


### PR DESCRIPTION
## What

Adds version pinning for the Redis Stack and RedisInsight container images used by the Redis templates, and changes the defaults away from `:latest`.

- `RedisTemplate::stack_version(tag)` pins the `redis/redis-stack` tag used when `with_redis_stack()` is enabled.
- `RedisClusterTemplate::stack_version(tag)` pins the `redis/redis-stack-server` tag for cluster nodes.
- `RedisClusterTemplate::redis_insight_version(tag)` pins the `redislabs/redisinsight` tag for the cluster GUI.
- Default tags are now pinned to verified known-good releases instead of `:latest`:
  - `redis/redis-stack` -> `7.4.0-v3`
  - `redis/redis-stack-server` -> `7.4.0-v3`
  - `redislabs/redisinsight` -> `2.60`
  - `redis/redisinsight` (standalone `RedisInsightTemplate`) -> `2.60`
- `custom_image()` / `custom_redis_image()` remain the general escape hatch for arbitrary image+tag.

## Why

`with_redis_stack()` previously hardcoded `redis/redis-stack-server:latest` (cluster) and `redis/redis-stack:latest` (basic), and the cluster GUI hardcoded `redislabs/redisinsight:latest`. With `:latest`, the image under test silently changes when upstream publishes, so CI runs are not reproducible. A redis-tower nightly tier needs pinned `redis-stack-server` tags to quote reproducible results (issue #249).

## Implementation notes

- Image-construction logic was extracted from the inline `start_node` / `start_redis_insight` bodies into small private helpers (`node_image` / `stack_image` / `insight_image` on the cluster, `stack_image` on the basic template), mirroring the existing `build_ping_args` helper style. This makes the resulting image arg unit-testable without a Docker daemon.
- Default tags were each verified to exist via `docker manifest inspect` against the registry before being chosen.
- The `pub(crate)` tag constants in `common.rs` are the single source of truth for the defaults; a new `REDIS_STACK_SERVER_IMAGE` constant was added for the `-server` variant and `REDIS_INSIGHT_CLUSTER_IMAGE` for the cluster's `redislabs/` org image.

## Test plan

- New unit tests assert the constructed image arg reflects the pinned default and any `stack_version` / `redis_insight_version` override, and that a `custom_*_image` still takes precedence:
  - `test_redis_stack_default_pinned_tag`, `test_redis_stack_version_override`, `test_redis_stack_version_ignored_without_stack` (basic)
  - `test_redis_cluster_stack_image_default_pinned`, `test_redis_cluster_stack_version_override`, `test_redis_cluster_node_image_default_and_custom`, `test_redis_cluster_insight_image_default_pinned`, `test_redis_cluster_insight_version_override` (cluster)
- Existing `test_redis_stack` integration tests (basic + cluster) continue to exercise `with_redis_stack()`; they assert module presence, which the pinned `7.4.0-v3` image satisfies. Docker integration is left to CI.
- Validation gate run locally: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --all-targets --no-default-features -- -D warnings`, `cargo test --lib --all-features` (790 passed), `cargo doc --no-deps --all-features` (zero warnings), `cargo test --doc --all-features` (411 passed).

Closes #249.