### PR TITLE
feat: add ToxiproxyTemplate and fault-injection helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ templates = [
     "template-mysql",
     "template-mongodb",
     "template-nginx",
+    "template-toxiproxy",
 ]
 
 # Individual template features
@@ -48,6 +49,8 @@ template-postgres = ["reqwest"]
 template-mysql = ["reqwest"]
 template-mongodb = ["reqwest"]
 template-nginx = ["reqwest"]
+# Toxiproxy fault-injection template (talks to the :8474 control API over HTTP).
+template-toxiproxy = ["reqwest"]
 
 # Future Redis variants
 template-redis-sentinel = ["template-redis"]
@@ -126,3 +129,8 @@ required-features = ["template-redis-enterprise"]
 name = "test_sentinel"
 path = "examples/test_sentinel.rs"
 required-features = ["template-redis"]
+
+[[example]]
+name = "toxiproxy_fault_injection"
+path = "examples/toxiproxy_fault_injection.rs"
+required-features = ["template-toxiproxy", "template-redis", "testing"]

--- a/examples/toxiproxy_fault_injection.rs
+++ b/examples/toxiproxy_fault_injection.rs
@@ -1,0 +1,109 @@
+//! Toxiproxy fault-injection example.
+//!
+//! Starts a Redis container and a Toxiproxy container on a shared network, routes
+//! a published host port through Toxiproxy to Redis, injects latency, and shows
+//! the guard-based fault helpers (pause/unpause/crash/partition/heal).
+//!
+//! Run with:
+//!   cargo run --example toxiproxy_fault_injection --features "template-toxiproxy,template-redis,testing"
+
+#[cfg(all(
+    feature = "template-toxiproxy",
+    feature = "template-redis",
+    feature = "testing"
+))]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use docker_wrapper::template::toxiproxy::{Toxic, ToxicStream};
+    use docker_wrapper::testing::ContainerGuard;
+    use docker_wrapper::{RedisTemplate, ToxiproxyTemplate};
+    use std::time::Duration;
+
+    let network = "toxiproxy-example-net";
+    let proxy_port = 16379;
+
+    println!("Starting Redis on network '{network}'...");
+    let redis = ContainerGuard::new(RedisTemplate::new("toxi-example-redis"))
+        .with_network(network)
+        .remove_network_on_drop(true)
+        .wait_for_ready(true)
+        .start()
+        .await?;
+
+    println!("Starting Toxiproxy on the same network...");
+    let toxiproxy_template = ToxiproxyTemplate::new("toxi-example-proxy")
+        .network(network)
+        .proxy_port(proxy_port);
+    let toxiproxy = ContainerGuard::new(toxiproxy_template)
+        .with_network(network)
+        .start()
+        .await?;
+
+    // Wait for the control API, then register a proxy: clients hit the published
+    // host port, Toxiproxy forwards to the Redis container by name.
+    toxiproxy.template().wait_for_control_api().await?;
+    toxiproxy
+        .template()
+        .create_proxy(
+            "redis",
+            format!("0.0.0.0:{proxy_port}"),
+            "toxi-example-redis:6379",
+        )
+        .await?;
+    println!("Proxy registered: localhost:{proxy_port} -> toxi-example-redis:6379");
+
+    // Inject 750ms of downstream latency on the proxy.
+    toxiproxy
+        .template()
+        .add_toxic(
+            "redis",
+            "slow",
+            ToxicStream::Downstream,
+            Toxic::latency(750),
+        )
+        .await?;
+    println!("Added a 750ms latency toxic. Connect to localhost:{proxy_port} to feel it.");
+
+    let proxies = toxiproxy.template().list_proxies().await?;
+    println!("Active proxies: {}", proxies.len());
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Remove the toxic and reset Toxiproxy to a clean state.
+    toxiproxy.template().remove_toxic("redis", "slow").await?;
+    toxiproxy.template().reset().await?;
+    println!("Latency toxic removed; Toxiproxy reset.");
+
+    // Demonstrate the guard fault helpers against the Redis container.
+    println!("Pausing Redis (simulated hang)...");
+    redis.pause().await?;
+    redis.unpause().await?;
+    println!("Resumed Redis.");
+
+    println!("Partitioning Redis from the network, then healing...");
+    redis.partition(network).await?;
+    redis.heal(network).await?;
+    println!("Redis reconnected.");
+
+    println!("Crashing Redis (SIGKILL)...");
+    redis.crash().await?;
+    println!("Redis killed.");
+
+    // Containers and the network are cleaned up automatically when the guards drop.
+    println!("Done. Cleaning up containers and network.");
+    Ok(())
+}
+
+#[cfg(not(all(
+    feature = "template-toxiproxy",
+    feature = "template-redis",
+    feature = "testing"
+)))]
+fn main() {
+    eprintln!(
+        "This example requires the 'template-toxiproxy', 'template-redis', and 'testing' features."
+    );
+    eprintln!(
+        "Run with: cargo run --example toxiproxy_fault_injection --features \"template-toxiproxy,template-redis,testing\""
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,7 +467,8 @@ pub mod tracing_compat;
     feature = "template-postgres",
     feature = "template-mysql",
     feature = "template-mongodb",
-    feature = "template-nginx"
+    feature = "template-nginx",
+    feature = "template-toxiproxy"
 ))]
 pub mod template;
 #[cfg(feature = "testing")]
@@ -584,7 +585,8 @@ pub use prerequisites::{
     feature = "template-postgres",
     feature = "template-mysql",
     feature = "template-mongodb",
-    feature = "template-nginx"
+    feature = "template-nginx",
+    feature = "template-toxiproxy"
 ))]
 pub use template::{Template, TemplateBuilder, TemplateConfig, TemplateError};
 
@@ -616,6 +618,10 @@ pub use template::database::{MongodbConnectionString, MongodbTemplate};
 // Web server templates
 #[cfg(feature = "template-nginx")]
 pub use template::web::NginxTemplate;
+
+// Fault-injection templates
+#[cfg(feature = "template-toxiproxy")]
+pub use template::toxiproxy::{ProxyInfo, Toxic, ToxicStream, ToxiproxyTemplate};
 
 /// The version of this crate
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/template.rs
+++ b/src/template.rs
@@ -35,6 +35,10 @@ pub mod database;
 #[cfg(feature = "template-nginx")]
 pub mod web;
 
+// Fault-injection templates
+#[cfg(feature = "template-toxiproxy")]
+pub mod toxiproxy;
+
 /// Result type for template operations
 pub type Result<T> = std::result::Result<T, TemplateError>;
 
@@ -632,3 +636,6 @@ pub use database::mongodb::{MongodbConnectionString, MongodbTemplate};
 
 #[cfg(feature = "template-nginx")]
 pub use web::nginx::NginxTemplate;
+
+#[cfg(feature = "template-toxiproxy")]
+pub use toxiproxy::{ProxyInfo, Toxic, ToxicStream, ToxiproxyTemplate};

--- a/src/template/toxiproxy.rs
+++ b/src/template/toxiproxy.rs
@@ -1,0 +1,748 @@
+//! Toxiproxy template for network fault injection.
+//!
+//! [Toxiproxy](https://github.com/Shopify/toxiproxy) is a TCP proxy that injects
+//! controllable faults (latency, bandwidth limits, connection drops, ...) between
+//! a client and an upstream service. This template runs the
+//! `ghcr.io/shopify/toxiproxy` container, publishes its `:8474` control API, and
+//! exposes a small typed client over that API so you can register proxies and add
+//! toxics without hand-rolling HTTP calls.
+//!
+//! # Quick Start
+//!
+//! ```rust,no_run
+//! use docker_wrapper::template::toxiproxy::{Toxic, ToxiproxyTemplate, ToxicStream};
+//! use docker_wrapper::Template;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Start Toxiproxy and wait for its control API to be ready.
+//! let toxiproxy = ToxiproxyTemplate::new("chaos")
+//!     .control_port(8474)
+//!     .proxy_port(16379);
+//! toxiproxy.start_and_wait().await?;
+//! toxiproxy.wait_for_control_api().await?;
+//!
+//! // Route a published host port through Toxiproxy to an upstream Redis.
+//! // The proxy listens on 0.0.0.0:16379 inside the container, which is published
+//! // to the host, so host clients can connect through the proxy.
+//! toxiproxy
+//!     .create_proxy("redis", "0.0.0.0:16379", "redis:6379")
+//!     .await?;
+//!
+//! // Inject 500ms of downstream latency.
+//! toxiproxy
+//!     .add_toxic("redis", "slow", ToxicStream::Downstream, Toxic::latency(500))
+//!     .await?;
+//!
+//! // ... run your client against localhost:16379 and observe the fault ...
+//!
+//! toxiproxy.remove_toxic("redis", "slow").await?;
+//! toxiproxy.reset().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Feature Flag
+//!
+//! This template requires the `template-toxiproxy` feature:
+//!
+//! ```toml
+//! [dependencies]
+//! docker-wrapper = { version = "0.11", features = ["template-toxiproxy"] }
+//! ```
+
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::return_self_not_must_use)]
+
+use crate::template::{Result, Template, TemplateConfig, TemplateError};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Default Toxiproxy image.
+const DEFAULT_IMAGE: &str = "ghcr.io/shopify/toxiproxy";
+/// Default Toxiproxy image tag.
+const DEFAULT_TAG: &str = "2.12.0";
+/// Default control API port.
+const DEFAULT_CONTROL_PORT: u16 = 8474;
+
+/// Direction a toxic applies to.
+///
+/// Toxiproxy applies toxics to one direction of a proxied connection. The
+/// downstream is data flowing from the upstream back to the client; the upstream
+/// is data flowing from the client to the upstream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToxicStream {
+    /// Data flowing from the upstream service back to the client.
+    Downstream,
+    /// Data flowing from the client to the upstream service.
+    Upstream,
+}
+
+impl ToxicStream {
+    /// The wire value Toxiproxy expects for this stream direction.
+    fn as_str(self) -> &'static str {
+        match self {
+            ToxicStream::Downstream => "downstream",
+            ToxicStream::Upstream => "upstream",
+        }
+    }
+}
+
+/// A typed Toxiproxy toxic.
+///
+/// Each variant maps to a Toxiproxy toxic type and carries its attributes. Use
+/// the associated constructors ([`Toxic::latency`], [`Toxic::bandwidth`], ...) to
+/// build a toxic, then pass it to [`ToxiproxyTemplate::add_toxic`].
+///
+/// See the [Toxiproxy toxics reference](https://github.com/Shopify/toxiproxy#toxics)
+/// for the full semantics of each type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Toxic {
+    /// Add a delay to all data, with optional random jitter.
+    ///
+    /// `latency` and `jitter` are in milliseconds.
+    Latency {
+        /// Base latency added to each packet, in milliseconds.
+        latency: u64,
+        /// Random jitter added on top of the base latency, in milliseconds.
+        jitter: u64,
+    },
+    /// Limit the connection to a maximum throughput.
+    ///
+    /// `rate` is in kilobytes per second.
+    Bandwidth {
+        /// Throughput limit in kilobytes per second.
+        rate: u64,
+    },
+    /// Stop all data and close the connection after `timeout` milliseconds.
+    ///
+    /// A `timeout` of `0` holds the connection open indefinitely without passing
+    /// data, which is useful for simulating a hung upstream.
+    Timeout {
+        /// Time to wait before closing the connection, in milliseconds.
+        timeout: u64,
+    },
+    /// Slice data into smaller packets to simulate fragmentation.
+    Slicer {
+        /// Average size of each packet, in bytes.
+        average_size: u64,
+        /// Variation in packet size, in bytes.
+        size_variation: u64,
+        /// Delay between sliced packets, in microseconds.
+        delay: u64,
+    },
+    /// Close the connection after a fixed number of bytes have been transmitted.
+    LimitData {
+        /// Number of bytes to allow before closing the connection.
+        bytes: u64,
+    },
+}
+
+impl Toxic {
+    /// Create a latency toxic with no jitter.
+    ///
+    /// `latency` is in milliseconds.
+    #[must_use]
+    pub fn latency(latency: u64) -> Self {
+        Toxic::Latency { latency, jitter: 0 }
+    }
+
+    /// Create a latency toxic with random jitter.
+    ///
+    /// Both `latency` and `jitter` are in milliseconds.
+    #[must_use]
+    pub fn jitter(latency: u64, jitter: u64) -> Self {
+        Toxic::Latency { latency, jitter }
+    }
+
+    /// Create a bandwidth toxic limiting throughput to `rate` kilobytes per second.
+    #[must_use]
+    pub fn bandwidth(rate: u64) -> Self {
+        Toxic::Bandwidth { rate }
+    }
+
+    /// Create a timeout toxic that closes the connection after `timeout` milliseconds.
+    ///
+    /// A `timeout` of `0` holds the connection open indefinitely.
+    #[must_use]
+    pub fn timeout(timeout: u64) -> Self {
+        Toxic::Timeout { timeout }
+    }
+
+    /// Create a slicer toxic that fragments data into smaller packets.
+    ///
+    /// `average_size` and `size_variation` are in bytes; `delay` is in microseconds.
+    #[must_use]
+    pub fn slicer(average_size: u64, size_variation: u64, delay: u64) -> Self {
+        Toxic::Slicer {
+            average_size,
+            size_variation,
+            delay,
+        }
+    }
+
+    /// Create a `limit_data` toxic that closes the connection after `bytes` bytes.
+    #[must_use]
+    pub fn limit_data(bytes: u64) -> Self {
+        Toxic::LimitData { bytes }
+    }
+
+    /// The Toxiproxy type name for this toxic.
+    fn type_name(&self) -> &'static str {
+        match self {
+            Toxic::Latency { .. } => "latency",
+            Toxic::Bandwidth { .. } => "bandwidth",
+            Toxic::Timeout { .. } => "timeout",
+            Toxic::Slicer { .. } => "slicer",
+            Toxic::LimitData { .. } => "limit_data",
+        }
+    }
+
+    /// The attribute map Toxiproxy expects for this toxic.
+    fn attributes(&self) -> HashMap<String, u64> {
+        let mut attrs = HashMap::new();
+        match *self {
+            Toxic::Latency { latency, jitter } => {
+                attrs.insert("latency".to_string(), latency);
+                attrs.insert("jitter".to_string(), jitter);
+            }
+            Toxic::Bandwidth { rate } => {
+                attrs.insert("rate".to_string(), rate);
+            }
+            Toxic::Timeout { timeout } => {
+                attrs.insert("timeout".to_string(), timeout);
+            }
+            Toxic::Slicer {
+                average_size,
+                size_variation,
+                delay,
+            } => {
+                attrs.insert("average_size".to_string(), average_size);
+                attrs.insert("size_variation".to_string(), size_variation);
+                attrs.insert("delay".to_string(), delay);
+            }
+            Toxic::LimitData { bytes } => {
+                attrs.insert("bytes".to_string(), bytes);
+            }
+        }
+        attrs
+    }
+}
+
+/// Request body for creating or updating a proxy via the control API.
+#[derive(Debug, Serialize)]
+struct ProxyRequest {
+    name: String,
+    listen: String,
+    upstream: String,
+    enabled: bool,
+}
+
+/// A proxy as returned by the Toxiproxy control API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProxyInfo {
+    /// Proxy name.
+    pub name: String,
+    /// Address the proxy listens on (inside the container).
+    pub listen: String,
+    /// Upstream address the proxy forwards to.
+    pub upstream: String,
+    /// Whether the proxy is currently enabled.
+    pub enabled: bool,
+}
+
+/// Request body for adding a toxic via the control API.
+#[derive(Debug, Serialize)]
+struct ToxicRequest {
+    name: String,
+    #[serde(rename = "type")]
+    toxic_type: String,
+    stream: String,
+    toxicity: f64,
+    attributes: HashMap<String, u64>,
+}
+
+/// Toxiproxy template for TCP fault injection.
+///
+/// Runs the `ghcr.io/shopify/toxiproxy` container and exposes a typed client over
+/// its `:8474` control API. Register proxies with [`create_proxy`](Self::create_proxy)
+/// and add toxics with [`add_toxic`](Self::add_toxic).
+///
+/// Proxies should listen on `0.0.0.0:<port>` and that port must be published (via
+/// [`proxy_port`](Self::proxy_port)) so host clients can connect through the proxy.
+pub struct ToxiproxyTemplate {
+    config: TemplateConfig,
+    control_port: u16,
+    api_ready_timeout: Duration,
+}
+
+impl ToxiproxyTemplate {
+    /// Create a new Toxiproxy template.
+    ///
+    /// The control API is published on port `8474` by default. Use
+    /// [`proxy_port`](Self::proxy_port) to also publish the ports your proxies
+    /// listen on so host clients can reach them.
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into();
+        let config = TemplateConfig {
+            name,
+            image: DEFAULT_IMAGE.to_string(),
+            tag: DEFAULT_TAG.to_string(),
+            ports: vec![(DEFAULT_CONTROL_PORT, DEFAULT_CONTROL_PORT)],
+            env: HashMap::new(),
+            volumes: Vec::new(),
+            network: None,
+            health_check: None,
+            auto_remove: false,
+            memory_limit: None,
+            cpu_limit: None,
+            platform: None,
+        };
+
+        Self {
+            config,
+            control_port: DEFAULT_CONTROL_PORT,
+            api_ready_timeout: Duration::from_secs(30),
+        }
+    }
+
+    /// Set the host port for the control API (default: 8474).
+    ///
+    /// This maps the host port to the container's `8474` control port.
+    pub fn control_port(mut self, port: u16) -> Self {
+        // Replace the existing control-port mapping (container side is always 8474).
+        if let Some(pos) = self
+            .config
+            .ports
+            .iter()
+            .position(|(_, c)| *c == DEFAULT_CONTROL_PORT)
+        {
+            self.config.ports[pos] = (port, DEFAULT_CONTROL_PORT);
+        } else {
+            self.config.ports.push((port, DEFAULT_CONTROL_PORT));
+        }
+        self.control_port = port;
+        self
+    }
+
+    /// Publish a proxy port so host clients can connect through a proxy.
+    ///
+    /// A proxy that listens on `0.0.0.0:<port>` inside the container is only
+    /// reachable from the host if that port is published. Call this once per port
+    /// you intend to proxy on. The same port is used on both the host and
+    /// container sides so the published address matches the proxy's `listen`
+    /// address.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::template::toxiproxy::ToxiproxyTemplate;
+    ///
+    /// let toxiproxy = ToxiproxyTemplate::new("chaos")
+    ///     .proxy_port(16379)
+    ///     .proxy_port(15432);
+    /// ```
+    pub fn proxy_port(mut self, port: u16) -> Self {
+        if !self
+            .config
+            .ports
+            .iter()
+            .any(|(h, c)| *h == port && *c == port)
+        {
+            self.config.ports.push((port, port));
+        }
+        self
+    }
+
+    /// Connect to a specific Docker network.
+    ///
+    /// Use this to place Toxiproxy on the same network as the upstream containers
+    /// it proxies, so it can reach them by container name.
+    pub fn network(mut self, network: impl Into<String>) -> Self {
+        self.config.network = Some(network.into());
+        self
+    }
+
+    /// Enable auto-remove when the container stops.
+    pub fn auto_remove(mut self) -> Self {
+        self.config.auto_remove = true;
+        self
+    }
+
+    /// Use a custom image and tag.
+    pub fn custom_image(mut self, image: impl Into<String>, tag: impl Into<String>) -> Self {
+        self.config.image = image.into();
+        self.config.tag = tag.into();
+        self
+    }
+
+    /// Set the platform for the container (e.g., "linux/arm64", "linux/amd64").
+    pub fn platform(mut self, platform: impl Into<String>) -> Self {
+        self.config.platform = Some(platform.into());
+        self
+    }
+
+    /// Set how long to wait for the control API to become ready (default: 30s).
+    pub fn api_ready_timeout(mut self, timeout: Duration) -> Self {
+        self.api_ready_timeout = timeout;
+        self
+    }
+
+    /// The base URL of the control API on the host.
+    fn control_url(&self) -> String {
+        format!("http://localhost:{}", self.control_port)
+    }
+
+    /// Build an HTTP client for talking to the control API.
+    fn http_client() -> Result<Client> {
+        Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|e| {
+                TemplateError::DockerError(crate::Error::custom(format!(
+                    "failed to build HTTP client: {e}"
+                )))
+            })
+    }
+
+    /// Wait for the Toxiproxy control API to start responding.
+    ///
+    /// Polls `GET /version` on the control port until it returns success or the
+    /// configured timeout elapses. Call this after [`start`](Template::start)
+    /// (or [`start_and_wait`](Template::start_and_wait)) before registering
+    /// proxies.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API does not respond within the timeout.
+    pub async fn wait_for_control_api(&self) -> Result<()> {
+        let client = Self::http_client()?;
+        let url = format!("{}/version", self.control_url());
+        let start = std::time::Instant::now();
+
+        while start.elapsed() < self.api_ready_timeout {
+            if let Ok(response) = client.get(&url).send().await {
+                if response.status().is_success() {
+                    return Ok(());
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        Err(TemplateError::Timeout(format!(
+            "Toxiproxy control API on port {} did not become ready within {}s",
+            self.control_port,
+            self.api_ready_timeout.as_secs()
+        )))
+    }
+
+    /// Register a new proxy.
+    ///
+    /// - `name` identifies the proxy in subsequent calls.
+    /// - `listen` is the address the proxy listens on inside the container. Use
+    ///   `0.0.0.0:<port>` with a published [`proxy_port`](Self::proxy_port) so host
+    ///   clients can connect through it.
+    /// - `upstream` is the address the proxy forwards to (e.g. `redis:6379` when on
+    ///   a shared network).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API request fails or returns a non-success
+    /// status (for example, if a proxy with the same name already exists).
+    pub async fn create_proxy(
+        &self,
+        name: impl Into<String>,
+        listen: impl Into<String>,
+        upstream: impl Into<String>,
+    ) -> Result<ProxyInfo> {
+        let client = Self::http_client()?;
+        let body = ProxyRequest {
+            name: name.into(),
+            listen: listen.into(),
+            upstream: upstream.into(),
+            enabled: true,
+        };
+
+        let url = format!("{}/proxies", self.control_url());
+        let response = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(TemplateError::InvalidConfig(format!(
+                "failed to create proxy '{}': HTTP {status}: {text}",
+                body.name
+            )));
+        }
+
+        response
+            .json::<ProxyInfo>()
+            .await
+            .map_err(|e| map_request_err(&e))
+    }
+
+    /// Add a toxic to an existing proxy.
+    ///
+    /// - `proxy` is the proxy name passed to [`create_proxy`](Self::create_proxy).
+    /// - `name` identifies the toxic for later removal.
+    /// - `stream` selects the direction the toxic applies to.
+    /// - `toxic` is the typed fault to inject.
+    ///
+    /// The toxic is applied with full toxicity (`1.0`), so it affects every
+    /// connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API request fails or returns a non-success
+    /// status.
+    pub async fn add_toxic(
+        &self,
+        proxy: &str,
+        name: impl Into<String>,
+        stream: ToxicStream,
+        toxic: Toxic,
+    ) -> Result<()> {
+        let client = Self::http_client()?;
+        let body = ToxicRequest {
+            name: name.into(),
+            toxic_type: toxic.type_name().to_string(),
+            stream: stream.as_str().to_string(),
+            toxicity: 1.0,
+            attributes: toxic.attributes(),
+        };
+
+        let url = format!("{}/proxies/{proxy}/toxics", self.control_url());
+        let response = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(TemplateError::InvalidConfig(format!(
+                "failed to add toxic '{}' to proxy '{proxy}': HTTP {status}: {text}",
+                body.name
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Remove a toxic from a proxy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API request fails or returns a non-success
+    /// status.
+    pub async fn remove_toxic(&self, proxy: &str, toxic: &str) -> Result<()> {
+        let client = Self::http_client()?;
+        let url = format!("{}/proxies/{proxy}/toxics/{toxic}", self.control_url());
+        let response = client
+            .delete(&url)
+            .send()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(TemplateError::InvalidConfig(format!(
+                "failed to remove toxic '{toxic}' from proxy '{proxy}': HTTP {status}: {text}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// List all registered proxies.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API request fails or the response cannot be
+    /// parsed.
+    pub async fn list_proxies(&self) -> Result<Vec<ProxyInfo>> {
+        let client = Self::http_client()?;
+        let url = format!("{}/proxies", self.control_url());
+        let response = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(TemplateError::InvalidConfig(format!(
+                "failed to list proxies: HTTP {status}: {text}"
+            )));
+        }
+
+        // The control API returns a map of name -> proxy.
+        let map = response
+            .json::<HashMap<String, ProxyInfo>>()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+        Ok(map.into_values().collect())
+    }
+
+    /// Reset all proxies and remove all toxics.
+    ///
+    /// This re-enables every proxy and clears all toxics, returning Toxiproxy to a
+    /// clean state without restarting the container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the control API request fails or returns a non-success
+    /// status.
+    pub async fn reset(&self) -> Result<()> {
+        let client = Self::http_client()?;
+        let url = format!("{}/reset", self.control_url());
+        let response = client
+            .post(&url)
+            .send()
+            .await
+            .map_err(|e| map_request_err(&e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(TemplateError::InvalidConfig(format!(
+                "failed to reset Toxiproxy: HTTP {status}: {text}"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// Map a reqwest error into a `TemplateError`.
+fn map_request_err(e: &reqwest::Error) -> TemplateError {
+    TemplateError::DockerError(crate::Error::custom(format!(
+        "Toxiproxy control API request failed: {e}"
+    )))
+}
+
+#[async_trait]
+impl Template for ToxiproxyTemplate {
+    fn name(&self) -> &str {
+        &self.config.name
+    }
+
+    fn config(&self) -> &TemplateConfig {
+        &self.config
+    }
+
+    fn config_mut(&mut self) -> &mut TemplateConfig {
+        &mut self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toxiproxy_template_defaults() {
+        let template = ToxiproxyTemplate::new("test-toxiproxy");
+        assert_eq!(template.name(), "test-toxiproxy");
+        assert_eq!(template.config().image, DEFAULT_IMAGE);
+        assert_eq!(template.config().tag, DEFAULT_TAG);
+        assert_eq!(template.control_port, DEFAULT_CONTROL_PORT);
+        assert_eq!(template.config().ports, vec![(8474, 8474)]);
+    }
+
+    #[test]
+    fn test_control_port_replaces_mapping() {
+        let template = ToxiproxyTemplate::new("test").control_port(18474);
+        assert_eq!(template.control_port, 18474);
+        // Container side stays 8474, host side updated; no duplicate mapping.
+        assert_eq!(template.config().ports, vec![(18474, 8474)]);
+        assert_eq!(template.control_url(), "http://localhost:18474");
+    }
+
+    #[test]
+    fn test_proxy_port_published() {
+        let template = ToxiproxyTemplate::new("test")
+            .proxy_port(16379)
+            .proxy_port(16379); // idempotent
+        let ports = &template.config().ports;
+        assert!(ports.contains(&(8474, 8474)));
+        assert!(ports.contains(&(16379, 16379)));
+        // Only added once despite the duplicate call.
+        assert_eq!(ports.iter().filter(|p| **p == (16379, 16379)).count(), 1);
+    }
+
+    #[test]
+    fn test_network_and_custom_image() {
+        let template = ToxiproxyTemplate::new("test")
+            .network("chaos-net")
+            .custom_image("ghcr.io/shopify/toxiproxy", "latest")
+            .platform("linux/arm64");
+        assert_eq!(template.config().network.as_deref(), Some("chaos-net"));
+        assert_eq!(template.config().image, "ghcr.io/shopify/toxiproxy");
+        assert_eq!(template.config().tag, "latest");
+        assert_eq!(template.config().platform.as_deref(), Some("linux/arm64"));
+    }
+
+    #[test]
+    fn test_toxic_latency_attributes() {
+        let toxic = Toxic::latency(500);
+        assert_eq!(toxic.type_name(), "latency");
+        let attrs = toxic.attributes();
+        assert_eq!(attrs.get("latency"), Some(&500));
+        assert_eq!(attrs.get("jitter"), Some(&0));
+
+        let toxic = Toxic::jitter(500, 100);
+        let attrs = toxic.attributes();
+        assert_eq!(attrs.get("latency"), Some(&500));
+        assert_eq!(attrs.get("jitter"), Some(&100));
+    }
+
+    #[test]
+    fn test_toxic_bandwidth_attributes() {
+        let toxic = Toxic::bandwidth(64);
+        assert_eq!(toxic.type_name(), "bandwidth");
+        assert_eq!(toxic.attributes().get("rate"), Some(&64));
+    }
+
+    #[test]
+    fn test_toxic_timeout_attributes() {
+        let toxic = Toxic::timeout(0);
+        assert_eq!(toxic.type_name(), "timeout");
+        assert_eq!(toxic.attributes().get("timeout"), Some(&0));
+    }
+
+    #[test]
+    fn test_toxic_slicer_attributes() {
+        let toxic = Toxic::slicer(64, 32, 10);
+        assert_eq!(toxic.type_name(), "slicer");
+        let attrs = toxic.attributes();
+        assert_eq!(attrs.get("average_size"), Some(&64));
+        assert_eq!(attrs.get("size_variation"), Some(&32));
+        assert_eq!(attrs.get("delay"), Some(&10));
+    }
+
+    #[test]
+    fn test_toxic_limit_data_attributes() {
+        let toxic = Toxic::limit_data(2048);
+        assert_eq!(toxic.type_name(), "limit_data");
+        assert_eq!(toxic.attributes().get("bytes"), Some(&2048));
+    }
+
+    #[test]
+    fn test_toxic_stream_wire_values() {
+        assert_eq!(ToxicStream::Downstream.as_str(), "downstream");
+        assert_eq!(ToxicStream::Upstream.as_str(), "upstream");
+    }
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -300,7 +300,9 @@
 use crate::command::DockerCommand;
 use crate::template::{HasConnectionString, Template, TemplateError};
 use crate::{
-    LogsCommand, NetworkCreateCommand, NetworkRmCommand, PortCommand, RmCommand, StopCommand,
+    KillCommand, LogsCommand, NetworkConnectCommand, NetworkCreateCommand,
+    NetworkDisconnectCommand, NetworkRmCommand, PauseCommand, PortCommand, RestartCommand,
+    RmCommand, StopCommand, UnpauseCommand,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -785,6 +787,145 @@ impl<T: Template> ContainerGuard<T> {
         if self.options.remove_on_drop {
             let _ = self.template.remove().await;
         }
+        Ok(())
+    }
+}
+
+/// Fault-injection helpers for chaos testing.
+///
+/// These are thin convenience wrappers over the underlying Docker commands
+/// ([`PauseCommand`], [`UnpauseCommand`], [`KillCommand`], [`RestartCommand`],
+/// [`NetworkConnectCommand`], [`NetworkDisconnectCommand`]) that target the
+/// guard's container by name. They make it easy to simulate real faults --
+/// hangs, crashes, and network partitions -- against a service under test
+/// without hand-rolling the command plumbing.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use docker_wrapper::testing::ContainerGuard;
+/// # use docker_wrapper::RedisTemplate;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let guard = ContainerGuard::new(RedisTemplate::new("redis"))
+///     .wait_for_ready(true)
+///     .start()
+///     .await?;
+///
+/// // Freeze the container's processes (simulate a hang), then resume.
+/// guard.pause().await?;
+/// guard.unpause().await?;
+///
+/// // Kill the container outright (simulate a crash).
+/// guard.crash().await?;
+/// # Ok(())
+/// # }
+/// ```
+impl<T: Template> ContainerGuard<T> {
+    /// Pause all processes in the container (simulate a hang).
+    ///
+    /// This freezes the container's processes using `docker pause`. They can be
+    /// resumed with [`unpause`](Self::unpause).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails (for example, if the
+    /// container is not running).
+    pub async fn pause(&self) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        PauseCommand::new(name)
+            .run()
+            .await
+            .map_err(TemplateError::DockerError)?;
+        Ok(())
+    }
+
+    /// Resume a paused container.
+    ///
+    /// This is the inverse of [`pause`](Self::pause) and uses `docker unpause`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails (for example, if the
+    /// container is not paused).
+    pub async fn unpause(&self) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        UnpauseCommand::new(name)
+            .run()
+            .await
+            .map_err(TemplateError::DockerError)?;
+        Ok(())
+    }
+
+    /// Kill the container immediately with SIGKILL (simulate a crash).
+    ///
+    /// This sends `SIGKILL` via `docker kill`, terminating the container
+    /// without a graceful shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails (for example, if the
+    /// container is not running).
+    pub async fn crash(&self) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        KillCommand::new(name)
+            .signal("SIGKILL")
+            .run()
+            .await
+            .map_err(TemplateError::DockerError)?;
+        Ok(())
+    }
+
+    /// Restart the container.
+    ///
+    /// This stops and starts the container via `docker restart`, which is useful
+    /// for simulating a recovery after a fault.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails.
+    pub async fn restart_container(&self) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        RestartCommand::new(name)
+            .execute()
+            .await
+            .map_err(TemplateError::DockerError)?;
+        Ok(())
+    }
+
+    /// Partition the container from a network (simulate a network outage).
+    ///
+    /// This disconnects the container from `network` via `docker network
+    /// disconnect`, cutting it off from other containers on that network. Use
+    /// [`heal`](Self::heal) to reconnect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails (for example, if the
+    /// container is not attached to the network).
+    pub async fn partition(&self, network: impl Into<String>) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        NetworkDisconnectCommand::new(network.into(), name)
+            .force()
+            .run()
+            .await
+            .map_err(TemplateError::DockerError)?;
+        Ok(())
+    }
+
+    /// Reconnect the container to a network after a partition.
+    ///
+    /// This is the inverse of [`partition`](Self::partition) and uses `docker
+    /// network connect`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Docker command fails.
+    pub async fn heal(&self, network: impl Into<String>) -> Result<(), TemplateError> {
+        let name = self.template.config().name.clone();
+        NetworkConnectCommand::new(network.into(), name)
+            .run()
+            .await
+            .map_err(TemplateError::DockerError)?;
         Ok(())
     }
 }

--- a/tests/toxiproxy_integration.rs
+++ b/tests/toxiproxy_integration.rs
@@ -1,0 +1,160 @@
+//! Integration tests for the Toxiproxy template.
+//!
+//! These tests start a real Toxiproxy container (plus a Redis container behind a
+//! proxy) and exercise the control API end to end: registering a proxy, sending
+//! traffic through the published proxy port, and injecting a latency toxic.
+//!
+//! Requires a running Docker daemon. Each test uses unique container and network
+//! names and cleans up after itself.
+
+#![cfg(all(feature = "template-toxiproxy", feature = "template-redis"))]
+
+use docker_wrapper::template::toxiproxy::{Toxic, ToxicStream};
+use docker_wrapper::{
+    DockerCommand, NetworkCreateCommand, NetworkRmCommand, RedisTemplate, Template,
+    ToxiproxyTemplate,
+};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Generate a unique suffix for test resources.
+fn unique(prefix: &str) -> String {
+    format!("{}-{}", prefix, uuid::Uuid::new_v4())
+}
+
+/// Pick a host port unlikely to collide with common services.
+fn random_port() -> u16 {
+    30000 + (uuid::Uuid::new_v4().as_u128() % 10000) as u16
+}
+
+/// Send a Redis PING through a TCP socket and return the round-trip duration.
+///
+/// Returns an error if the connection or exchange fails, or if the reply does not
+/// look like a Redis PONG.
+async fn ping_through(addr: &str) -> Result<Duration, Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    let mut stream = TcpStream::connect(addr).await?;
+    stream.write_all(b"PING\r\n").await?;
+    stream.flush().await?;
+
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf)).await??;
+    let elapsed = start.elapsed();
+
+    let reply = String::from_utf8_lossy(&buf[..n]);
+    if !reply.to_uppercase().contains("PONG") {
+        return Err(format!("unexpected reply from {addr}: {reply:?}").into());
+    }
+    Ok(elapsed)
+}
+
+#[tokio::test]
+async fn test_toxiproxy_proxy_and_latency_toxic() -> Result<(), Box<dyn std::error::Error>> {
+    // Skip gracefully if Docker is unavailable.
+    if docker_wrapper::VersionCommand::new()
+        .execute()
+        .await
+        .is_err()
+    {
+        eprintln!("Docker not available, skipping test");
+        return Ok(());
+    }
+
+    let network = unique("toxi-net");
+    let redis_name = unique("toxi-redis");
+    let proxy_name = unique("toxi-proxy");
+    let proxy_port = random_port();
+
+    // Shared network so Toxiproxy can reach Redis by container name.
+    let _ = NetworkCreateCommand::new(&network)
+        .driver("bridge")
+        .execute()
+        .await;
+
+    // Run the body in a closure so we can always clean up afterwards.
+    let result = async {
+        // Start Redis on the shared network.
+        let mut redis = RedisTemplate::new(&redis_name);
+        redis.config_mut().network = Some(network.clone());
+        redis.start_and_wait().await?;
+        redis.wait_for_ready().await?;
+
+        // Start Toxiproxy on the same network, publishing the control port and the
+        // proxy port so the test process can connect through it.
+        let mut toxiproxy = ToxiproxyTemplate::new(&proxy_name)
+            .proxy_port(proxy_port)
+            .api_ready_timeout(Duration::from_secs(30));
+        toxiproxy.config_mut().network = Some(network.clone());
+        toxiproxy.start_and_wait().await?;
+        toxiproxy.wait_for_control_api().await?;
+
+        // Register the proxy: listen on the published port, forward to Redis.
+        let proxy = toxiproxy
+            .create_proxy(
+                "redis",
+                format!("0.0.0.0:{proxy_port}"),
+                format!("{redis_name}:6379"),
+            )
+            .await?;
+        assert_eq!(proxy.name, "redis");
+        assert!(proxy.enabled);
+
+        // The proxy should show up in the listing.
+        let proxies = toxiproxy.list_proxies().await?;
+        assert!(
+            proxies.iter().any(|p| p.name == "redis"),
+            "expected 'redis' proxy in listing, got {proxies:?}"
+        );
+
+        let addr = format!("127.0.0.1:{proxy_port}");
+
+        // Baseline: PING through the clean proxy should be fast.
+        let baseline = ping_through(&addr).await?;
+
+        // Inject 600ms of downstream latency.
+        toxiproxy
+            .add_toxic(
+                "redis",
+                "slow",
+                ToxicStream::Downstream,
+                Toxic::latency(600),
+            )
+            .await?;
+
+        // Now a PING through the proxy should take noticeably longer.
+        let slowed = ping_through(&addr).await?;
+        assert!(
+            slowed >= Duration::from_millis(500),
+            "expected latency toxic to add delay (baseline {baseline:?}, slowed {slowed:?})"
+        );
+
+        // Remove the toxic and confirm latency returns to baseline-ish.
+        toxiproxy.remove_toxic("redis", "slow").await?;
+        let recovered = ping_through(&addr).await?;
+        assert!(
+            recovered < Duration::from_millis(500),
+            "expected latency to recover after removing toxic, got {recovered:?}"
+        );
+
+        // Reset should leave the proxy in place but clear toxics.
+        toxiproxy.reset().await?;
+
+        // Clean up the containers.
+        toxiproxy.stop().await?;
+        toxiproxy.remove().await?;
+        redis.stop().await?;
+        redis.remove().await?;
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    }
+    .await;
+
+    // Best-effort cleanup of containers (in case the body returned early) and the
+    // network. Ignore errors since resources may already be gone.
+    let _ = RedisTemplate::new(&redis_name).remove().await;
+    let _ = ToxiproxyTemplate::new(&proxy_name).remove().await;
+    let _ = NetworkRmCommand::new(&network).run().await;
+
+    result
+}


### PR DESCRIPTION
## What

Packages the chaos-testing story as a first-class docker-wrapper capability, as requested in #245.

### 1. `ToxiproxyTemplate` (new `template-toxiproxy` feature)

A template that runs `ghcr.io/shopify/toxiproxy` and exposes its `:8474` control API through a small typed client (built on the existing feature-gated `reqwest` dependency):

- `create_proxy(name, listen, upstream)` registers a proxy. Proxies listen on published ports (`proxy_port(...)`) so host clients can connect through them.
- `add_toxic(proxy, name, stream, toxic)` / `remove_toxic(...)` with a typed `Toxic` enum covering `latency`, `jitter`, `bandwidth`, `timeout`, `slicer`, and `limit_data`, plus a `ToxicStream` direction (upstream/downstream).
- `list_proxies()` and `reset()`.
- `wait_for_control_api()` polls `GET /version` until the control API is ready.

Lives in `src/template/toxiproxy.rs`, declared in `src/template.rs`, re-exported from the crate root. The new feature is added to the `templates` umbrella and follows the existing `template-*` naming.

### 2. Fault helpers on `ContainerGuard` (`src/testing.rs`)

Thin wrappers over existing commands, gated behind the `testing` feature so default builds are unaffected:

- `pause()` / `unpause()` -- `PauseCommand` / `UnpauseCommand`
- `crash()` -- `KillCommand` with SIGKILL
- `restart_container()` -- `RestartCommand`
- `partition(network)` / `heal(network)` -- `NetworkDisconnectCommand` / `NetworkConnectCommand`

## Why

The raw fault primitives already exist, but composing a chaos harness (running Toxiproxy, registering proxies/toxics over HTTP, wiring containers onto a shared network) took ~50-100 lines of glue per project. This packages it. Context: redis-tower is building a fault-injection matrix to evaluate circuit-breaker and retry behavior under real faults.

## Evidence / test plan

- Unit tests for the toxic attribute mapping, stream wire values, and port/image builder behavior (9 new, all green in `cargo test --lib --all-features`).
- Doc test on `proxy_port` plus a `no_run` module-level quick-start.
- Integration test `tests/toxiproxy_integration.rs` starts Redis behind a Toxiproxy proxy on a shared network, sends a Redis PING through the published proxy port, injects a 600ms latency toxic, asserts the round-trip slows, removes the toxic, and asserts recovery -- with full cleanup of containers and the network. (Local Docker daemon was unavailable; the test compiles and is left for CI's Docker Integration job, which is authoritative.)
- Example `examples/toxiproxy_fault_injection.rs` wires Redis + Toxiproxy end to end and demonstrates the guard fault helpers.

Validation gate run locally and passing: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --all-targets --no-default-features -- -D warnings`, `cargo test --lib --all-features` (810 passed), `cargo doc --no-deps --all-features`, `cargo test --doc --all-features` (414 passed).

Closes #245.