### PR TITLE
feat: add TLS support for Redis templates

### DIFF
--- a/src/template/redis/basic.rs
+++ b/src/template/redis/basic.rs
@@ -8,7 +8,8 @@
 
 use super::common::{
     default_redis_health_check, redis_config_volume, redis_connection_string, redis_data_volume,
-    DEFAULT_REDIS_IMAGE, DEFAULT_REDIS_TAG, REDIS_STACK_IMAGE, REDIS_STACK_TAG,
+    redis_tls_connection_string, redis_tls_server_args, redis_tls_volume, DEFAULT_REDIS_IMAGE,
+    DEFAULT_REDIS_TAG, DEFAULT_REDIS_TLS_PORT, REDIS_STACK_IMAGE, REDIS_STACK_TAG,
 };
 use crate::template::{HasConnectionString, Template, TemplateConfig};
 use async_trait::async_trait;
@@ -19,6 +20,14 @@ pub struct RedisTemplate {
     config: TemplateConfig,
     use_redis_stack: bool,
     stack_tag: String,
+    /// Host directory containing TLS certificate material, mounted read-only
+    /// into the container when TLS is enabled.
+    tls_certs_dir: Option<String>,
+    /// Host-side port mapped to the container TLS port when TLS is enabled.
+    tls_port: u16,
+    /// When true, the plaintext port is disabled (`--port 0`) and only TLS is
+    /// served.
+    tls_only: bool,
 }
 
 impl RedisTemplate {
@@ -47,6 +56,9 @@ impl RedisTemplate {
             config,
             use_redis_stack: false,
             stack_tag: REDIS_STACK_TAG.to_string(),
+            tls_certs_dir: None,
+            tls_port: DEFAULT_REDIS_TLS_PORT,
+            tls_only: false,
         }
     }
 
@@ -216,6 +228,107 @@ impl RedisTemplate {
         self.config.platform = Some(platform.into());
         self
     }
+
+    /// Enable TLS, bind-mounting the given host certificate directory.
+    ///
+    /// The directory is mounted read-only into the container and Redis is
+    /// started with `--tls-port`, `--tls-cert-file`, `--tls-key-file` and
+    /// `--tls-ca-cert-file`. The directory **must** contain these files:
+    ///
+    /// - `redis.crt` -- the server certificate
+    /// - `redis.key` -- the server private key
+    /// - `ca.crt` -- the CA certificate used to verify client certificates
+    ///
+    /// By default the plaintext port stays open alongside TLS; call
+    /// [`tls_only`](Self::tls_only) to disable plaintext (`--port 0`). The TLS
+    /// port is published on the host (6380 by default, override with
+    /// [`tls_port`](Self::tls_port)).
+    ///
+    /// # Generating throwaway certificates
+    ///
+    /// For local testing you can generate a self-signed CA and server
+    /// certificate with `openssl`:
+    ///
+    /// ```sh
+    /// openssl genrsa -out ca.key 2048
+    /// openssl req -x509 -new -nodes -key ca.key -sha256 -days 365 \
+    ///   -subj "/CN=test-ca" -out ca.crt
+    /// openssl genrsa -out redis.key 2048
+    /// openssl req -new -key redis.key -subj "/CN=localhost" -out redis.csr
+    /// openssl x509 -req -in redis.csr -CA ca.crt -CAkey ca.key \
+    ///   -CAcreateserial -days 365 -sha256 -out redis.crt
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::template::{RedisTemplate, Template};
+    /// use docker_wrapper::DockerCommand;
+    ///
+    /// let template = RedisTemplate::new("tls-redis").tls("/path/to/certs");
+    /// let args = template.build_command().build_command_args();
+    /// assert!(args.contains(&"--tls-port".to_string()));
+    /// assert!(args.contains(&"6380".to_string()));
+    /// ```
+    pub fn tls(mut self, certs_dir: impl Into<String>) -> Self {
+        self.tls_certs_dir = Some(certs_dir.into());
+        self
+    }
+
+    /// Set the host-side port published for TLS connections (default 6380).
+    ///
+    /// Only has an effect when TLS is enabled via [`tls`](Self::tls).
+    pub fn tls_port(mut self, port: u16) -> Self {
+        self.tls_port = port;
+        self
+    }
+
+    /// Disable the plaintext port and serve only TLS.
+    ///
+    /// Sets `--port 0` (which tells Redis to stop listening on the plaintext
+    /// port) and skips publishing the plaintext port mapping. Only has an
+    /// effect when TLS is enabled via [`tls`](Self::tls).
+    pub fn tls_only(mut self) -> Self {
+        self.tls_only = true;
+        self
+    }
+
+    /// Returns true when TLS has been enabled on this template.
+    fn tls_enabled(&self) -> bool {
+        self.tls_certs_dir.is_some()
+    }
+
+    /// Returns the TLS connection string in URL format, or `None` when TLS is
+    /// not enabled.
+    ///
+    /// Format: `rediss://[:password@]host:port`, where `port` is the published
+    /// TLS port (6380 by default, see [`tls_port`](Self::tls_port)).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::template::RedisTemplate;
+    ///
+    /// let template = RedisTemplate::new("my-redis").tls("/certs");
+    /// assert_eq!(
+    ///     template.tls_connection_string().as_deref(),
+    ///     Some("rediss://localhost:6380")
+    /// );
+    ///
+    /// let plaintext = RedisTemplate::new("my-redis");
+    /// assert_eq!(plaintext.tls_connection_string(), None);
+    /// ```
+    pub fn tls_connection_string(&self) -> Option<String> {
+        if !self.tls_enabled() {
+            return None;
+        }
+        let password = self.config.env.get("REDIS_PASSWORD").map(String::as_str);
+        Some(redis_tls_connection_string(
+            "localhost",
+            self.tls_port,
+            password,
+        ))
+    }
 }
 
 #[async_trait]
@@ -300,8 +413,15 @@ impl Template for RedisTemplate {
         // host's network namespace, so published ports are ignored by Docker
         // (and emit a warning); skip them entirely.
         if !self.uses_host_network() {
-            for (host, container) in &config.ports {
-                cmd = cmd.port(*host, *container);
+            // Publish the plaintext port unless TLS-only mode disabled it.
+            if !(self.tls_enabled() && self.tls_only) {
+                for (host, container) in &config.ports {
+                    cmd = cmd.port(*host, *container);
+                }
+            }
+            // Publish the TLS port when TLS is enabled.
+            if self.tls_enabled() {
+                cmd = cmd.port(self.tls_port, DEFAULT_REDIS_TLS_PORT);
             }
         }
 
@@ -312,6 +432,12 @@ impl Template for RedisTemplate {
             } else {
                 cmd = cmd.volume(&mount.source, &mount.target);
             }
+        }
+
+        // Mount the TLS certificate directory read-only when TLS is enabled.
+        if let Some(ref certs_dir) = self.tls_certs_dir {
+            let mount = redis_tls_volume(certs_dir.clone());
+            cmd = cmd.volume_ro(&mount.source, &mount.target);
         }
 
         // Add network
@@ -343,28 +469,47 @@ impl Template for RedisTemplate {
             cmd = cmd.remove();
         }
 
-        // Handle Redis-specific command args
-        if let Some(password) = config.env.get("REDIS_PASSWORD") {
+        // Handle Redis-specific command args. Password and TLS both require
+        // overriding the redis-server flags; compose them together so they can
+        // coexist.
+        let password = config.env.get("REDIS_PASSWORD");
+        if password.is_some() || self.tls_enabled() {
+            // Flags shared by both the Stack (REDIS_ARGS) and basic
+            // (entrypoint override) paths.
+            let mut server_flags: Vec<String> = Vec::new();
+            if let Some(password) = password {
+                server_flags.push("--requirepass".to_string());
+                server_flags.push(password.clone());
+                server_flags.push("--protected-mode".to_string());
+                server_flags.push("yes".to_string());
+            }
+            if self.tls_enabled() {
+                if self.tls_only {
+                    // Disable the plaintext listener.
+                    server_flags.push("--port".to_string());
+                    server_flags.push("0".to_string());
+                }
+                server_flags.extend(redis_tls_server_args(DEFAULT_REDIS_TLS_PORT));
+            }
+
             if self.use_redis_stack {
-                // For Redis Stack, use environment variable instead of command override
-                cmd = cmd.env("REDIS_ARGS", format!("--requirepass {password}"));
+                // For Redis Stack, pass flags via the REDIS_ARGS environment
+                // variable instead of overriding the entrypoint.
+                cmd = cmd.env("REDIS_ARGS", server_flags.join(" "));
             } else {
-                // For basic Redis, override entrypoint to bypass docker-entrypoint.sh and directly run redis-server
-                cmd = cmd.entrypoint("redis-server").cmd(vec![
-                    "--requirepass".to_string(),
-                    password.clone(),
-                    "--protected-mode".to_string(),
-                    "yes".to_string(),
-                ]);
+                // For basic Redis, override the entrypoint to bypass
+                // docker-entrypoint.sh and run redis-server directly.
+                cmd = cmd.entrypoint("redis-server").cmd(server_flags);
             }
         }
 
-        // If custom config file is mounted
+        // If a custom config file is mounted (and neither password nor TLS
+        // overrode the command), launch redis-server with that config file.
         let has_config = config
             .volumes
             .iter()
             .any(|v| v.target == "/usr/local/etc/redis/redis.conf");
-        if has_config && config.env.get("REDIS_PASSWORD").is_none() {
+        if has_config && password.is_none() && !self.tls_enabled() {
             cmd = cmd.cmd(vec![
                 "redis-server".to_string(),
                 "/usr/local/etc/redis/redis.conf".to_string(),
@@ -380,6 +525,13 @@ impl HasConnectionString for RedisTemplate {
     ///
     /// Format: `redis://[:password@]host:port`
     ///
+    /// When the template is configured for TLS-only access (see
+    /// [`tls_only`](RedisTemplate::tls_only)) the plaintext port is disabled, so
+    /// this returns the `rediss://` TLS endpoint instead. When TLS is enabled
+    /// *alongside* plaintext, this still returns the plaintext URL; use
+    /// [`tls_connection_string`](RedisTemplate::tls_connection_string) for the
+    /// TLS endpoint.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -392,8 +544,19 @@ impl HasConnectionString for RedisTemplate {
     ///     .port(6380)
     ///     .password("secret");
     /// assert_eq!(template_with_pass.connection_string(), "redis://:secret@localhost:6380");
+    ///
+    /// // TLS-only falls back to the rediss:// endpoint.
+    /// let tls = RedisTemplate::new("my-redis").tls("/certs").tls_only();
+    /// assert_eq!(tls.connection_string(), "rediss://localhost:6380");
     /// ```
     fn connection_string(&self) -> String {
+        // In TLS-only mode the plaintext port is closed, so the only usable
+        // endpoint is the TLS one.
+        if self.tls_enabled() && self.tls_only {
+            if let Some(tls) = self.tls_connection_string() {
+                return tls;
+            }
+        }
         let port = self.config.ports.first().map_or(6379, |(h, _)| *h);
         let password = self.config.env.get("REDIS_PASSWORD").map(String::as_str);
         redis_connection_string("localhost", port, password)
@@ -563,5 +726,112 @@ mod tests {
 
         let template = RedisTemplate::new("test-redis");
         assert_eq!(template.connection_string(), "redis://localhost:6379");
+    }
+
+    #[test]
+    fn test_redis_tls_args_and_volume() {
+        let template = RedisTemplate::new("test-redis").tls("/tmp/certs");
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+
+        // TLS server flags are present.
+        assert!(args.contains(&"--tls-port".to_string()));
+        assert!(args.contains(&"6380".to_string()));
+        assert!(args.contains(&"--tls-cert-file".to_string()));
+        assert!(args.contains(&"/tls/redis.crt".to_string()));
+        assert!(args.contains(&"--tls-key-file".to_string()));
+        assert!(args.contains(&"/tls/redis.key".to_string()));
+        assert!(args.contains(&"--tls-ca-cert-file".to_string()));
+        assert!(args.contains(&"/tls/ca.crt".to_string()));
+
+        // Certs are mounted read-only at /tls.
+        assert!(args.contains(&"/tmp/certs:/tls:ro".to_string()));
+
+        // The TLS port is published, and plaintext stays open by default.
+        assert!(args.contains(&"6380:6380".to_string()));
+        assert!(args.contains(&"6379:6379".to_string()));
+
+        // Plaintext is not disabled by default.
+        assert!(!args.windows(2).any(|w| w == ["--port", "0"]));
+    }
+
+    #[test]
+    fn test_redis_tls_custom_port() {
+        let template = RedisTemplate::new("test-redis")
+            .tls("/tmp/certs")
+            .tls_port(7000);
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+
+        // The host TLS port maps to the container TLS port.
+        assert!(args.contains(&"7000:6380".to_string()));
+    }
+
+    #[test]
+    fn test_redis_tls_only_disables_plaintext() {
+        let template = RedisTemplate::new("test-redis")
+            .tls("/tmp/certs")
+            .tls_only();
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+
+        // Plaintext is disabled via --port 0 and not published.
+        assert!(args.windows(2).any(|w| w == ["--port", "0"]));
+        assert!(!args.contains(&"6379:6379".to_string()));
+
+        // The TLS port is still published.
+        assert!(args.contains(&"6380:6380".to_string()));
+    }
+
+    #[test]
+    fn test_redis_tls_with_password() {
+        let template = RedisTemplate::new("test-redis")
+            .tls("/tmp/certs")
+            .password("secret");
+
+        let cmd = template.build_command();
+        let args = cmd.build_command_args();
+
+        // Both password and TLS flags coexist.
+        assert!(args.windows(2).any(|w| w == ["--requirepass", "secret"]));
+        assert!(args.contains(&"--tls-port".to_string()));
+    }
+
+    #[test]
+    fn test_redis_tls_connection_string() {
+        let template = RedisTemplate::new("test-redis").tls("/tmp/certs");
+        assert_eq!(
+            template.tls_connection_string().as_deref(),
+            Some("rediss://localhost:6380")
+        );
+
+        let with_pass = RedisTemplate::new("test-redis")
+            .tls("/tmp/certs")
+            .tls_port(7000)
+            .password("secret");
+        assert_eq!(
+            with_pass.tls_connection_string().as_deref(),
+            Some("rediss://:secret@localhost:7000")
+        );
+    }
+
+    #[test]
+    fn test_redis_tls_connection_string_none_without_tls() {
+        let template = RedisTemplate::new("test-redis");
+        assert_eq!(template.tls_connection_string(), None);
+    }
+
+    #[test]
+    fn test_redis_tls_only_connection_string_falls_back_to_tls() {
+        use crate::template::HasConnectionString;
+
+        let template = RedisTemplate::new("test-redis")
+            .tls("/tmp/certs")
+            .tls_only();
+        // Plaintext is closed, so connection_string() returns the TLS endpoint.
+        assert_eq!(template.connection_string(), "rediss://localhost:6380");
     }
 }

--- a/src/template/redis/cluster.rs
+++ b/src/template/redis/cluster.rs
@@ -11,7 +11,9 @@
 #![allow(clippy::struct_excessive_bools)]
 
 use super::common::{
-    REDIS_INSIGHT_CLUSTER_IMAGE, REDIS_INSIGHT_TAG, REDIS_STACK_SERVER_IMAGE, REDIS_STACK_TAG,
+    redis_tls_server_args, REDIS_INSIGHT_CLUSTER_IMAGE, REDIS_INSIGHT_TAG,
+    REDIS_STACK_SERVER_IMAGE, REDIS_STACK_TAG, REDIS_TLS_CA_FILE, REDIS_TLS_CERT_FILE,
+    REDIS_TLS_DIR, REDIS_TLS_KEY_FILE,
 };
 use crate::template::{Template, TemplateConfig, TemplateError};
 use crate::{DockerCommand, ExecCommand, NetworkCreateCommand, RunCommand};
@@ -59,6 +61,9 @@ pub struct RedisClusterTemplate {
     redis_tag: Option<String>,
     /// Platform for containers
     platform: Option<String>,
+    /// Host directory containing TLS certificate material, mounted read-only
+    /// into every node when TLS is enabled.
+    tls_certs_dir: Option<String>,
 }
 
 impl RedisClusterTemplate {
@@ -88,6 +93,7 @@ impl RedisClusterTemplate {
             redis_image: None,
             redis_tag: None,
             platform: None,
+            tls_certs_dir: None,
         }
     }
 
@@ -371,6 +377,60 @@ impl RedisClusterTemplate {
         self
     }
 
+    /// Enable TLS for every cluster node, bind-mounting the given host
+    /// certificate directory read-only into each container.
+    ///
+    /// The directory **must** contain these files (the same layout used by the
+    /// single-node [`RedisTemplate`](super::RedisTemplate)):
+    ///
+    /// - `redis.crt` -- the server certificate
+    /// - `redis.key` -- the server private key
+    /// - `ca.crt` -- the CA certificate used to verify peers
+    ///
+    /// Each node is started with `--tls-port` set to its data port, `--port 0`
+    /// (plaintext disabled), and `--tls-cluster yes`/`--tls-replication yes` so
+    /// that the cluster bus and replication links are encrypted too. This mirrors
+    /// Redis's documented cluster-over-TLS layout: unlike the single-node
+    /// template, a TLS cluster is **always TLS-only** on the data port -- the
+    /// gossip protocol cannot mix plaintext and TLS nodes. The
+    /// `redis-cli --cluster create`, readiness, and inspection calls all connect
+    /// with `--tls` and the mounted certificates.
+    ///
+    /// See [`RedisTemplate::tls`](super::RedisTemplate::tls) for an `openssl`
+    /// recipe to generate throwaway certificates for local testing.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use docker_wrapper::RedisClusterTemplate;
+    ///
+    /// let cluster = RedisClusterTemplate::new("tls-cluster").tls("/path/to/certs");
+    /// ```
+    pub fn tls(mut self, certs_dir: impl Into<String>) -> Self {
+        self.tls_certs_dir = Some(certs_dir.into());
+        self
+    }
+
+    /// Returns true when TLS has been enabled on this cluster.
+    fn tls_enabled(&self) -> bool {
+        self.tls_certs_dir.is_some()
+    }
+
+    /// Append the `redis-cli` TLS flags (`--tls --cacert --cert --key`) to a
+    /// command vector when TLS is enabled, so management commands can reach the
+    /// TLS-only nodes.
+    fn push_cli_tls_args(&self, args: &mut Vec<String>) {
+        if self.tls_enabled() {
+            args.push("--tls".to_string());
+            args.push("--cacert".to_string());
+            args.push(format!("{REDIS_TLS_DIR}/{REDIS_TLS_CA_FILE}"));
+            args.push("--cert".to_string());
+            args.push(format!("{REDIS_TLS_DIR}/{REDIS_TLS_CERT_FILE}"));
+            args.push("--key".to_string());
+            args.push(format!("{REDIS_TLS_DIR}/{REDIS_TLS_KEY_FILE}"));
+        }
+    }
+
     /// Get the total number of nodes
     fn total_nodes(&self) -> usize {
         self.num_masters + (self.num_masters * self.num_replicas)
@@ -512,6 +572,7 @@ impl RedisClusterTemplate {
             role_args.push("-p".to_string());
             role_args.push(self.node_internal_port(index).to_string());
         }
+        self.push_cli_tls_args(&mut role_args);
         if let Some(ref password) = self.password {
             role_args.push("-a".to_string());
             role_args.push(password.clone());
@@ -579,6 +640,11 @@ impl RedisClusterTemplate {
             cmd = cmd.volume(&volume_name, "/data");
         }
 
+        // Mount the TLS certificate directory read-only when TLS is enabled.
+        if let Some(ref certs_dir) = self.tls_certs_dir {
+            cmd = cmd.volume_ro(certs_dir, REDIS_TLS_DIR);
+        }
+
         // Add platform if specified
         if let Some(ref platform) = self.platform {
             cmd = cmd.platform(platform);
@@ -600,9 +666,23 @@ impl RedisClusterTemplate {
             self.node_timeout.to_string(),
             "--appendonly".to_string(),
             "yes".to_string(),
-            "--port".to_string(),
-            internal_port.to_string(),
         ];
+
+        if self.tls_enabled() {
+            // Cluster-over-TLS: serve TLS on the node's data port, disable the
+            // plaintext listener, and encrypt the cluster bus and replication
+            // links. This is the layout Redis documents for TLS clusters.
+            redis_args.push("--port".to_string());
+            redis_args.push("0".to_string());
+            redis_args.extend(redis_tls_server_args(internal_port));
+            redis_args.push("--tls-cluster".to_string());
+            redis_args.push("yes".to_string());
+            redis_args.push("--tls-replication".to_string());
+            redis_args.push("yes".to_string());
+        } else {
+            redis_args.push("--port".to_string());
+            redis_args.push(internal_port.to_string());
+        }
 
         // Add password if configured
         if let Some(ref password) = self.password {
@@ -701,7 +781,8 @@ impl RedisClusterTemplate {
     ///
     /// In host networking mode each node listens on its own `port_base + index`
     /// port rather than the default 6379, so an explicit `-p` is added to target
-    /// the right node inside the shared host namespace.
+    /// the right node inside the shared host namespace. When TLS is enabled the
+    /// `--tls` flags are appended so the check can reach the TLS-only node.
     fn build_ping_args(&self, node_index: usize) -> Vec<String> {
         let mut args = vec!["redis-cli".to_string()];
 
@@ -709,6 +790,8 @@ impl RedisClusterTemplate {
             args.push("-p".to_string());
             args.push(self.node_internal_port(node_index).to_string());
         }
+
+        self.push_cli_tls_args(&mut args);
 
         if let Some(ref password) = self.password {
             args.push("-a".to_string());
@@ -800,6 +883,9 @@ impl RedisClusterTemplate {
             create_args.push(self.num_replicas.to_string());
         }
 
+        // Connect over TLS when enabled (nodes are TLS-only).
+        self.push_cli_tls_args(&mut create_args);
+
         // Add password if configured
         if let Some(ref password) = self.password {
             create_args.push("-a".to_string());
@@ -829,6 +915,8 @@ impl RedisClusterTemplate {
             "info".to_string(),
             self.node_cluster_address(0),
         ];
+
+        self.push_cli_tls_args(&mut info_args);
 
         if let Some(ref password) = self.password {
             info_args.push("-a".to_string());
@@ -1657,5 +1745,89 @@ mod tests {
             &["localhost:7000", "localhost:7001", "localhost:7002"]
         );
         assert_eq!(template.node(1).unwrap().host_port, 7001);
+    }
+
+    #[test]
+    fn test_tls_disabled_by_default() {
+        let template = RedisClusterTemplate::new("test-cluster");
+        assert!(!template.tls_enabled());
+
+        // No TLS flags leak into the management commands.
+        let mut args = Vec::new();
+        template.push_cli_tls_args(&mut args);
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn test_tls_enables_flag() {
+        let template = RedisClusterTemplate::new("test-cluster").tls("/tmp/certs");
+        assert!(template.tls_enabled());
+    }
+
+    #[test]
+    fn test_push_cli_tls_args_when_enabled() {
+        let template = RedisClusterTemplate::new("test-cluster").tls("/tmp/certs");
+
+        let mut args = vec!["redis-cli".to_string()];
+        template.push_cli_tls_args(&mut args);
+
+        assert_eq!(
+            args,
+            vec![
+                "redis-cli",
+                "--tls",
+                "--cacert",
+                "/tls/ca.crt",
+                "--cert",
+                "/tls/redis.crt",
+                "--key",
+                "/tls/redis.key",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_ping_args_with_tls() {
+        let template = RedisClusterTemplate::new("test-cluster").tls("/tmp/certs");
+
+        // Bridge mode + TLS: default port, but TLS flags are appended.
+        assert_eq!(
+            template.build_ping_args(0),
+            vec![
+                "redis-cli",
+                "--tls",
+                "--cacert",
+                "/tls/ca.crt",
+                "--cert",
+                "/tls/redis.crt",
+                "--key",
+                "/tls/redis.key",
+                "ping",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_ping_args_with_tls_and_password() {
+        let template = RedisClusterTemplate::new("test-cluster")
+            .tls("/tmp/certs")
+            .password("secret");
+
+        assert_eq!(
+            template.build_ping_args(0),
+            vec![
+                "redis-cli",
+                "--tls",
+                "--cacert",
+                "/tls/ca.crt",
+                "--cert",
+                "/tls/redis.crt",
+                "--key",
+                "/tls/redis.key",
+                "-a",
+                "secret",
+                "ping",
+            ]
+        );
     }
 }

--- a/src/template/redis/common.rs
+++ b/src/template/redis/common.rs
@@ -46,6 +46,24 @@ pub const REDIS_INSIGHT_TAG: &str = "2.60";
 /// Default RedisInsight port
 pub const DEFAULT_REDIS_INSIGHT_PORT: u16 = 5540;
 
+/// Container path where TLS certificate material is bind-mounted.
+///
+/// When TLS is enabled the host certificate directory is mounted here
+/// read-only and the `--tls-*-file` arguments reference files inside it.
+pub const REDIS_TLS_DIR: &str = "/tls";
+
+/// Server certificate file name expected inside the mounted TLS directory.
+pub const REDIS_TLS_CERT_FILE: &str = "redis.crt";
+
+/// Private key file name expected inside the mounted TLS directory.
+pub const REDIS_TLS_KEY_FILE: &str = "redis.key";
+
+/// CA certificate file name expected inside the mounted TLS directory.
+pub const REDIS_TLS_CA_FILE: &str = "ca.crt";
+
+/// Default container-side port Redis listens on for TLS connections.
+pub const DEFAULT_REDIS_TLS_PORT: u16 = 6380;
+
 /// Create a default health check for Redis
 pub fn default_redis_health_check() -> HealthCheck {
     HealthCheck {
@@ -64,6 +82,44 @@ pub fn redis_connection_string(host: &str, port: u16, password: Option<&str>) ->
     match password {
         Some(pass) => format!("redis://:{}@{}:{}", pass, host, port),
         None => format!("redis://{}:{}", host, port),
+    }
+}
+
+/// Build a Redis TLS connection string (`rediss://` scheme).
+#[allow(dead_code)]
+pub fn redis_tls_connection_string(host: &str, port: u16, password: Option<&str>) -> String {
+    match password {
+        Some(pass) => format!("rediss://:{pass}@{host}:{port}"),
+        None => format!("rediss://{host}:{port}"),
+    }
+}
+
+/// Build the `redis-server` TLS arguments for the given container-side TLS port.
+///
+/// Emits `--tls-port`, `--tls-cert-file`, `--tls-key-file` and
+/// `--tls-ca-cert-file`, each referencing a file inside [`REDIS_TLS_DIR`]. The
+/// caller is responsible for bind-mounting the host certificate directory there
+/// (see [`redis_tls_volume`]) and for deciding whether the plaintext port stays
+/// open -- passing `--port 0` separately disables plaintext.
+pub fn redis_tls_server_args(tls_container_port: u16) -> Vec<String> {
+    vec![
+        "--tls-port".to_string(),
+        tls_container_port.to_string(),
+        "--tls-cert-file".to_string(),
+        format!("{REDIS_TLS_DIR}/{REDIS_TLS_CERT_FILE}"),
+        "--tls-key-file".to_string(),
+        format!("{REDIS_TLS_DIR}/{REDIS_TLS_KEY_FILE}"),
+        "--tls-ca-cert-file".to_string(),
+        format!("{REDIS_TLS_DIR}/{REDIS_TLS_CA_FILE}"),
+    ]
+}
+
+/// Create a read-only volume mount for a Redis TLS certificate directory.
+pub fn redis_tls_volume(certs_dir: impl Into<String>) -> VolumeMount {
+    VolumeMount {
+        source: certs_dir.into(),
+        target: REDIS_TLS_DIR.to_string(),
+        read_only: true,
     }
 }
 

--- a/tests/redis_tls_integration.rs
+++ b/tests/redis_tls_integration.rs
@@ -1,0 +1,258 @@
+//! Integration tests for Redis template TLS support.
+//!
+//! These tests generate throwaway self-signed certificates with `openssl` in a
+//! temporary directory, start a TLS-enabled Redis container, and verify a
+//! `redis-cli --tls` connection succeeds. They are skipped automatically when
+//! Docker or `openssl` is unavailable.
+
+#[cfg(feature = "template-redis")]
+mod redis_tls_tests {
+    use docker_wrapper::{DockerCommand, RedisTemplate, Template, VersionCommand};
+    use std::path::Path;
+    use std::process::Command;
+
+    /// Generate a unique container name for tests.
+    fn test_container_name(suffix: &str) -> String {
+        format!("test-redis-tls-{}-{}", suffix, uuid::Uuid::new_v4())
+    }
+
+    /// Generate a random port for testing to avoid conflicts.
+    fn random_port() -> u16 {
+        30000 + (uuid::Uuid::new_v4().as_u128() % 10000) as u16
+    }
+
+    /// Returns true if Docker is available on this host.
+    async fn docker_available() -> bool {
+        VersionCommand::new().execute().await.is_ok()
+    }
+
+    /// Returns true if the `openssl` binary is available on this host.
+    fn openssl_available() -> bool {
+        Command::new("openssl")
+            .arg("version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Run an `openssl` subcommand, asserting it succeeds.
+    fn openssl(dir: &Path, args: &[&str]) {
+        let output = Command::new("openssl")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("failed to spawn openssl");
+        assert!(
+            output.status.success(),
+            "openssl {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Generate a self-signed CA plus a server certificate signed by it, using
+    /// the file names the Redis templates expect (`ca.crt`, `redis.crt`,
+    /// `redis.key`). The mounted directory must be world-readable so the
+    /// container's `redis` user can read the key.
+    fn generate_certs(dir: &Path) {
+        // CA key + self-signed CA cert.
+        openssl(dir, &["genrsa", "-out", "ca.key", "2048"]);
+        openssl(
+            dir,
+            &[
+                "req",
+                "-x509",
+                "-new",
+                "-nodes",
+                "-key",
+                "ca.key",
+                "-sha256",
+                "-days",
+                "1",
+                "-subj",
+                "/CN=docker-wrapper-test-ca",
+                "-out",
+                "ca.crt",
+            ],
+        );
+
+        // Server key + CSR + cert signed by the CA.
+        openssl(dir, &["genrsa", "-out", "redis.key", "2048"]);
+        openssl(
+            dir,
+            &[
+                "req",
+                "-new",
+                "-key",
+                "redis.key",
+                "-subj",
+                "/CN=localhost",
+                "-out",
+                "redis.csr",
+            ],
+        );
+        openssl(
+            dir,
+            &[
+                "x509",
+                "-req",
+                "-in",
+                "redis.csr",
+                "-CA",
+                "ca.crt",
+                "-CAkey",
+                "ca.key",
+                "-CAcreateserial",
+                "-days",
+                "1",
+                "-sha256",
+                "-out",
+                "redis.crt",
+            ],
+        );
+
+        // The container's redis user must be able to read the key material.
+        for file in ["ca.crt", "redis.crt", "redis.key"] {
+            let path = dir.join(file);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+                    .expect("set cert permissions");
+            }
+            assert!(path.exists(), "expected {} to exist", file);
+        }
+    }
+
+    /// In-container redis-cli arguments for a TLS ping against the TLS port.
+    fn tls_ping(port: u16) -> Vec<String> {
+        vec![
+            "redis-cli".to_string(),
+            "--tls".to_string(),
+            "-p".to_string(),
+            port.to_string(),
+            "--cacert".to_string(),
+            "/tls/ca.crt".to_string(),
+            "--cert".to_string(),
+            "/tls/redis.crt".to_string(),
+            "--key".to_string(),
+            "/tls/redis.key".to_string(),
+            "ping".to_string(),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_redis_tls_connection() -> Result<(), Box<dyn std::error::Error>> {
+        if !docker_available().await {
+            eprintln!("Docker not available, skipping TLS test");
+            return Ok(());
+        }
+        if !openssl_available() {
+            eprintln!("openssl not available, skipping TLS test");
+            return Ok(());
+        }
+
+        let certs = tempfile::tempdir()?;
+        generate_certs(certs.path());
+
+        let name = test_container_name("connect");
+        let tls_port = random_port();
+        // Keep plaintext open so the template's readiness ping works, then prove
+        // the TLS listener accepts a redis-cli --tls connection.
+        let redis = RedisTemplate::new(&name)
+            .port(random_port())
+            .tls_port(tls_port)
+            .tls(certs.path().to_string_lossy().to_string());
+
+        let container_id = redis.start_and_wait().await?;
+        assert!(!container_id.is_empty());
+
+        // A TLS ping against the container TLS port (6380) must succeed.
+        let tls_cli = tls_ping(6380);
+        let cli: Vec<&str> = tls_cli.iter().map(String::as_str).collect();
+        let result = redis.exec(cli).await?;
+        assert_eq!(
+            result.stdout.trim(),
+            "PONG",
+            "TLS ping failed: stdout={:?} stderr={:?}",
+            result.stdout,
+            result.stderr
+        );
+
+        // The plaintext port is still serving in non-tls-only mode.
+        let plain = redis.exec(vec!["redis-cli", "ping"]).await?;
+        assert_eq!(plain.stdout.trim(), "PONG");
+
+        // Clean up.
+        redis.stop().await?;
+        redis.remove().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_redis_tls_only_disables_plaintext() -> Result<(), Box<dyn std::error::Error>> {
+        if !docker_available().await {
+            eprintln!("Docker not available, skipping TLS test");
+            return Ok(());
+        }
+        if !openssl_available() {
+            eprintln!("openssl not available, skipping TLS test");
+            return Ok(());
+        }
+
+        let certs = tempfile::tempdir()?;
+        generate_certs(certs.path());
+
+        let name = test_container_name("tls-only");
+        let tls_port = random_port();
+        // TLS-only: plaintext is disabled (--port 0). The container's own health
+        // check is plaintext, so it never reports healthy here; we start without
+        // waiting and poll the TLS listener directly instead.
+        let redis = RedisTemplate::new(&name)
+            .tls_port(tls_port)
+            .tls(certs.path().to_string_lossy().to_string())
+            .tls_only();
+
+        redis.start().await?;
+
+        // Poll the TLS listener until it answers PONG (the container is up but
+        // has no plaintext readiness signal).
+        let tls_cli = tls_ping(6380);
+        let mut ready = false;
+        for _ in 0..60 {
+            let cli: Vec<&str> = tls_cli.iter().map(String::as_str).collect();
+            if let Ok(out) = redis.exec(cli).await {
+                if out.stdout.trim() == "PONG" {
+                    ready = true;
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        assert!(ready, "TLS-only Redis did not answer a TLS ping in time");
+
+        // Plaintext must be refused: a plaintext redis-cli ping against the
+        // disabled port either fails the exec (connection refused) or, at most,
+        // never returns PONG. Both outcomes prove plaintext is closed.
+        let plain = redis.exec(vec!["redis-cli", "-p", "6379", "ping"]).await;
+        match plain {
+            Ok(out) => assert_ne!(
+                out.stdout.trim(),
+                "PONG",
+                "plaintext port should be disabled in TLS-only mode, got: {:?}",
+                out.stdout
+            ),
+            Err(_) => {
+                // Connection refused on the plaintext port is the expected
+                // result in TLS-only mode.
+            }
+        }
+
+        // Clean up.
+        redis.stop().await?;
+        redis.remove().await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What

Adds TLS support to the Redis templates, so a TLS Redis no longer needs hand-rolled `RunCommand` plumbing with cert volume mounts and `--tls-*` args.

### Single-node `RedisTemplate`
- `.tls(certs_dir)` -- bind-mounts the host cert directory read-only at `/tls` and starts `redis-server` with `--tls-port`, `--tls-cert-file`, `--tls-key-file`, `--tls-ca-cert-file`. Expects the conventional `redis.crt` / `redis.key` / `ca.crt` file names (documented).
- Plaintext stays open alongside TLS by default. TLS listens on container port 6380, published on a configurable host port (`.tls_port(port)`, default 6380).
- `.tls_only()` -- disables the plaintext port via `--port 0` and stops publishing it.
- Connection helpers account for TLS: `tls_connection_string()` returns the `rediss://` URL; `connection_string()` falls back to the `rediss://` endpoint in TLS-only mode (since plaintext is closed). TLS composes with password auth.

### `RedisClusterTemplate`
- `.tls(certs_dir)` -- every node runs TLS-only on its data port with `--tls-cluster yes` / `--tls-replication yes`, mirroring Redis's documented cluster-over-TLS layout (the gossip protocol cannot mix plaintext and TLS nodes). Readiness polling, `redis-cli --cluster create`, `cluster info`, and `node_role` all connect with `redis-cli --tls` and the mounted certificates.

### No new default dependencies
Self-signed cert generation is not pulled in as a heavyweight default. Instead the `tls()` rustdoc documents an `openssl` one-liner recipe, and the integration test generates throwaway certs with `openssl` in a temp dir.

## Why

Closes the gap noted in the issue: redis-tower keeps TLS coverage on its process-based harness because the containerized templates could not exercise TLS. Template TLS lets the containerized version-matrix tier cover TLS paths too.

## Evidence / test plan

- Unit tests for arg construction on both templates (TLS flags, cert mount, `--port 0` in TLS-only, custom TLS port, password coexistence, `rediss://` connection strings, cluster `redis-cli --tls` flag assembly). `cargo test --lib --all-features`: 841 passed.
- New `tests/redis_tls_integration.rs`: generates a self-signed CA + server cert with `openssl`, starts a TLS Redis, and asserts a `redis-cli --tls` ping returns `PONG`; a second test asserts plaintext is refused in TLS-only mode. Skipped automatically when Docker or `openssl` is unavailable. Both pass against a live Docker daemon (29.4.3).
- Existing `tests/redis_template_integration.rs` (7 tests incl. password and Redis Stack, which share the refactored `build_command` path) pass against live Docker -- no regression.
- Full gate green: `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo clippy --all-targets --no-default-features -- -D warnings`, `cargo doc --no-deps --all-features`, `cargo test --doc --all-features` (422 passed).

Closes #244.
